### PR TITLE
Add possibility to use relative path in javaHome setting

### DIFF
--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -39,6 +39,9 @@ function checkJavaRuntime(): Promise<any> {
     let source: string;
     let javaHome: string = readJavaConfig();
     if (javaHome) {
+      if (!path.isAbsolute(javaHome) && workspace.workspaceFolders && workspace.workspaceFolders[0].uri.scheme === "file") {
+        path.resolve(workspace.workspaceFolders[0].uri.fsPath, javaHome);
+      }
       source =
         "The 'sonarlint.ls.javaHome' variable defined in VS Code settings";
     } else {


### PR DESCRIPTION
Hi, in our company we have a java jre in our repo and share the workspace settings of vscode. Currently it is not possible to set a relative path from vscode workspace folder to the java jre, because the extension always expects the javaHome path to be absolute. Or at least the extension says it can't find jre folder. I'd like to fix it with this changes.