### PR TITLE
SLVSCODE-35 Add basic java support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SonarLint for Visual Studio Code
 
-SonarLint is an IDE extension that helps you detect and fix quality issues as you write code. Like a spell checker, SonarLint squiggles flaws so they can be fixed before committing code. You can get it directly from the VS Code Marketplace and it will then detect new bugs and quality issues as you code (JavaScript, TypeScript, PHP and Python)
+SonarLint is an IDE extension that helps you detect and fix quality issues as you write code. Like a spell checker, SonarLint squiggles flaws so they can be fixed before committing code. You can get it directly from the VS Code Marketplace and it will then detect new bugs and quality issues as you code (JavaScript, TypeScript, PHP, Python & Java)
 
 ## How it works
 
@@ -20,6 +20,7 @@ Check the rules to see what SonarLint can do for you:
 - [TypeScript rules](https://rules.sonarsource.com/typescript)
 - [Python rules](https://rules.sonarsource.com/python)
 - [PHP rules](https://rules.sonarsource.com/php)
+- [Java rules](https://rules.sonarsource.com/java)
 
 You will benefit from the following code analyzers: [SonarJS](https://redirect.sonarsource.com/plugins/javascript.html), [SonarTS](https://redirect.sonarsource.com/plugins/typescript.html), [SonarPython](https://redirect.sonarsource.com/plugins/python.html) and [SonarPHP](https://redirect.sonarsource.com/plugins/php.html)
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "onLanguage:vue",
     "onLanguage:html",
     "onLanguage:jsp",
+    "onLanguage:java",
     "onCommand:sonarlint.updateServersAndBinding"
   ],
   "extensionDependency": [

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -9,6 +9,7 @@ const sonarPhpVersion = '2.16.0.4355';
 const sonarPythonVersion = '1.12.0.2726';
 const sonarTsVersion = '1.9.0.3766';
 const sonarHtmlVersion = '3.1.0.1615';
+const sonarJavaVersion = '5.11.0.17289';
 
 if (!fs.existsSync('server')) {
   fs.mkdirSync('server');
@@ -41,6 +42,10 @@ downloadIfNeeded(
 downloadIfNeeded(
   `https://repox.jfrog.io/repox/sonarsource/org/sonarsource/html/sonar-html-plugin/${sonarHtmlVersion}/sonar-html-plugin-${sonarHtmlVersion}.jar`,
   'analyzers/sonarhtml.jar'
+);
+downloadIfNeeded(
+  `https://repox.jfrog.io/repox/sonarsource/org/sonarsource/java/sonar-java-plugin/${sonarJavaVersion}/sonar-java-plugin-${sonarJavaVersion}.jar`,
+  'analyzers/sonarjava.jar'
 );
 
 function downloadIfNeeded(url, dest) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,6 +96,7 @@ function languageServerCommand(
   params.push(toUrl(Path.resolve(context.extensionPath, 'analyzers', 'sonarpython.jar')));
   params.push(toUrl(Path.resolve(context.extensionPath, 'analyzers', 'sonarts.jar')));
   params.push(toUrl(Path.resolve(context.extensionPath, 'analyzers', 'sonarhtml.jar')));
+  params.push(toUrl(Path.resolve(context.extensionPath, 'analyzers', 'sonarjava.jar')));
   return { command: javaExecutablePath, args: params };
 }
 
@@ -175,7 +176,8 @@ export function activate(context: VSCode.ExtensionContext) {
       { scheme: 'file', language: 'typescriptreact' },
       { scheme: 'file', language: 'vue' },
       { scheme: 'file', language: 'html' },
-      { scheme: 'file', language: 'jsp' }
+      { scheme: 'file', language: 'jsp' },
+      { scheme: 'file', language: 'java' }
     ],
     synchronize: {
       configurationSection: 'sonarlint'
@@ -339,15 +341,15 @@ function computeRuleDescPanelContent(
   return `<!doctype html><html>
 		<head>
 		<style type="text/css">
-			body { 
-				font-family: Helvetica Neue,Segoe UI,Helvetica,Arial,sans-serif; 
-				font-size: 13px; line-height: 1.23076923; 
+			body {
+				font-family: Helvetica Neue,Segoe UI,Helvetica,Arial,sans-serif;
+				font-size: 13px; line-height: 1.23076923;
 			}
-			
+
 			h1 { font-size: 14px;font-weight: 500; }
 			h2 { line-height: 24px;}
 			a { border-bottom: 1px solid rgba(230, 230, 230, .1); color: #236a97; cursor: pointer; outline: none; text-decoration: none; transition: all .2s ease;}
-			
+
 			.rule-desc { line-height: 1.5;}
 			.rule-desc { line-height: 1.5;}
 			.rule-desc h2 { font-size: 16px; font-weight: 400;}


### PR DESCRIPTION
See https://jira.sonarsource.com/browse/SLVSCODE-35

In an effort to get some movement on that feature request, i've had a go at adding java support.

There's not many changes but it seems to be work. I have not really done much testing and i'm not sure how TBH. 

I used the latest version found via https://mvnrepository.com/artifact/org.sonarsource.java/sonar-java-plugin/5.11.0.17289

Here is a screenshot showing it working:

<img width="1136" alt="screenshot 2019-02-26 at 16 30 40" src="https://user-images.githubusercontent.com/102141/53424776-20600080-39e4-11e9-8540-95700537412c.png">

