### PR TITLE
Fix language server freeze after a few analyses

### DIFF
--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const crypto = require('crypto');
 const request = require('request');
 
-const languageServerVersion = '4.3.0.2460';
+const languageServerVersion = '4.3.0.2475';
 const sonarJsVersion = '5.1.1.7506';
 const sonarPhpVersion = '3.0.0.4537';
 const sonarPythonVersion = '1.12.0.2726';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,12 @@ function logToSonarLintOutput(message) {
   }
 }
 
+function appendToSonarLintOutput(message) {
+  if (sonarlintOutput) {
+    sonarlintOutput.append(message);
+  }
+}
+
 function runJavaServer(context: VSCode.ExtensionContext): Thenable<StreamInfo> {
   return resolveRequirements()
     .catch(error => {
@@ -71,10 +77,10 @@ function runJavaServer(context: VSCode.ExtensionContext): Thenable<StreamInfo> {
           const process = ChildProcess.spawn(command, args);
 
           process.stdout.on('data', function(data) {
-            logToSonarLintOutput(data.toString());
+            appendToSonarLintOutput(data.toString());
           });
           process.stderr.on('data', function(data) {
-            logToSonarLintOutput(data.toString());
+            appendToSonarLintOutput(data.toString());
           });
         });
       });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,14 +63,16 @@ function runJavaServer(context: VSCode.ExtensionContext): Thenable<StreamInfo> {
           console.log(`Executing ${command} ${args.join(' ')}`);
           const process = ChildProcess.spawn(command, args);
 
-          if (VERBOSE_LOGS) {
-            process.stdout.on('data', function(data) {
+          process.stdout.on('data', function(data) {
+            if (VERBOSE_LOGS) {
               console.log(data.toString());
-            });
-            process.stderr.on('data', function(data) {
+            }
+          });
+          process.stderr.on('data', function(data) {
+            if (VERBOSE_LOGS) {
               console.error(data.toString());
-            });
-          }
+            }
+          });
         });
       });
     });


### PR DESCRIPTION
a2745cbbab0b46a25088d66d5038f2829aef1d69 introduced a regression: since the standard streams of the forked process were not consumed, the buffer got full on language server side and hung analyses.

This new version unconditionally attaches stream consumers, then only logs conditionally.