### PR TITLE
SLCORE-244 Trigger diagnostics refresh on rules configuration change

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,11 +71,11 @@
           "type": "object",
           "scope": "application",
           "default": {},
-          "markdownDescription": "Configure rules. In connected mode, this configuration is overridden by the server's quality profile.\n\nExample:\n\n    \"sonarlint.rules\": {\n        \"javascript:UnusedVariable\": {\n            \"level\": \"off\"\n        }\n    }\n",
+          "markdownDescription": "Configure rules. In connected mode, this configuration is overridden by the projects's quality profile, as configured on server side.\n\nExample:\n\n    \"sonarlint.rules\": {\n        \"javascript:UnusedVariable\": {\n            \"level\": \"off\"\n        }\n    }\n",
           "patternProperties": {
             "^[^:]+:[^:]+$": {
               "type": "object",
-              "description": "One rule configuration",
+              "markdownDescription": "Property names are rule keys in the form: `repo:key`",
               "properties": {
                 "level": {
                   "type": "string",

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -8,7 +8,7 @@ const jarDependencies = [
   {
     groupId: 'org/sonarsource/sonarlint/core',
     artifactId: 'sonarlint-language-server',
-    version: '4.4.0.2546',
+    version: '4.4.0.2558',
     output: 'server/sonarlint-ls.jar'
   },
   {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -274,7 +274,7 @@ export function activate(context: VSCode.ExtensionContext) {
   });
 
   VSCode.workspace.onDidChangeConfiguration(async event => {
-    if(event.affectsConfiguration("sonarlint.rules")) {
+    if (event.affectsConfiguration("sonarlint.rules")) {
       const supportedLangs = DOCUMENT_SELECTOR.map(s => s.language);
       const refreshArgs = VSCode.workspace.textDocuments
         // Ask for a refresh of diagnostics only on open documents supported by the language server


### PR DESCRIPTION
Client side of SLCORE-244, using dedicated command to trigger a refresh of diagnostics after an update to rule configuration.