### PR TITLE
SLVSCODE-76 Add IDE version in telemetry

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -217,6 +217,7 @@ export function activate(context: VSCode.ExtensionContext) {
         telemetryStorage: Path.resolve(context.extensionPath, '..', 'sonarlint_usage'),
         productName: 'SonarLint VSCode',
         productVersion: VSCode.extensions.getExtension('SonarSource.sonarlint-vscode').packageJSON.version,
+        ideVersion: VSCode.version,
         disableTelemetry: configuration ? configuration.get('disableTelemetry', false) : false,
         typeScriptLocation: tsPath ? Path.dirname(Path.dirname(tsPath)) : undefined,
         includeRuleDetailsInCodeAction: true,


### PR DESCRIPTION
Pending SLCORE update, this passes the expected value to the telemetry client.