### PR TITLE
Improve Java home detection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "args": ["--extensionDevelopmentPath=${workspaceFolder}" ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": [ "${workspaceFolder}/out/src/**/*.js" ],
+            "outFiles": [ "${workspaceFolder}/dist/**/*.js" ],
             "preLaunchTask": "npm: watch"
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceFolder}/out/src/**/*.js" ],
-            "preLaunchTask": "npm: webpack"
+            "preLaunchTask": "npm: watch"
         },
         {
             "name": "Extension Tests",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,9 +2680,9 @@
       "dev": true
     },
     "find-java-home": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-0.2.0.tgz",
-      "integrity": "sha512-nq5PFOHxE1VSEbdDVkLoA2bAcRnG4ETqJO8ipFq3glIWA52hdWCXYX3emuUyMAQfaqFU4Ea85gqcgaPmOApEPA==",
+      "version": "1.0.1",
+      "resolved": "https://repox.jfrog.io/repox/api/npm/npm/find-java-home/-/find-java-home-1.0.1.tgz",
+      "integrity": "sha1-7UZBQVFU52uEgq0EPEiicekVVxo=",
       "requires": {
         "which": "~1.0.5",
         "winreg": "~1.2.2"
@@ -9686,7 +9686,7 @@
     },
     "which": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "resolved": "https://repox.jfrog.io/repox/api/npm/npm/which/-/which-1.0.9.tgz",
       "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8="
     },
     "which-module": {
@@ -9697,7 +9697,7 @@
     },
     "winreg": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
+      "resolved": "https://repox.jfrog.io/repox/api/npm/npm/winreg/-/winreg-1.2.4.tgz",
       "integrity": "sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs="
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,17 @@
       "type": "object",
       "title": "SonarLint",
       "properties": {
+        "sonarlint.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the SonarLint language server.",
+          "scope": "window"
+        },
         "sonarlint.testFilePattern": {
           "type": "string",
           "default": "{**/test/**,**/*test*,**/*Test*}",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
   },
   "dependencies": {
     "expand-home-dir": "0.0.3",
-    "find-java-home": "0.2.0",
+    "find-java-home": "1.0.1",
     "open": "6.0.0",
     "path-exists": "3.0.0",
     "vscode-languageclient": "5.2.1"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,27 @@
+/* --------------------------------------------------------------------------------------------
+ * SonarLint for VisualStudio Code
+ * Copyright (C) 2017-2019 SonarSource SA
+ * sonarlint@sonarsource.com
+ * Licensed under the LGPLv3 License. See LICENSE.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+/**
+ * Commonly used commands
+ */
+export namespace Commands {
+  /**
+   * Open Browser
+   */
+  export const OPEN_BROWSER = 'vscode.open';
+
+  /**
+   * Open settings.json
+   */
+  export const OPEN_JSON_SETTINGS = 'workbench.action.openSettingsJson';
+
+  /**
+   * Open settings
+   */
+  export const OPEN_SETTINGS = 'workbench.action.openSettings';
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -209,7 +209,8 @@ export function activate(context: VSCode.ExtensionContext) {
   oldConfig = getSonarLintConfiguration();
 
   // Create the language client and start the client.
-  languageClient = new LanguageClient('sonarlint-vscode', 'SonarLint Language Server', serverOptions, clientOptions);
+  // id parameter is used to load 'sonarlint.trace.server' configuration
+  languageClient = new LanguageClient('sonarlint', 'SonarLint Language Server', serverOptions, clientOptions);
 
   VSCode.commands.registerCommand(
     'SonarLint.OpenRuleDesc',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,8 +63,8 @@ function runJavaServer(context: VSCode.ExtensionContext): Thenable<StreamInfo> {
     .catch(error => {
       //show error
       VSCode.window.showErrorMessage(error.message, error.label).then(selection => {
-        if (error.label && error.label === selection && error.openUrl) {
-          VSCode.commands.executeCommand('vscode.open', error.openUrl);
+        if (error.label && error.label === selection && error.command) {
+          VSCode.commands.executeCommand(error.command, error.commandParam);
         }
       });
       // rethrow to disrupt the chain.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -191,6 +191,7 @@ export function activate(context: VSCode.ExtensionContext) {
       return {
         testFilePattern: configuration && configuration.get('testFilePattern'),
         analyzerProperties: configuration && configuration.get('analyzerProperties'),
+        productKey: 'vscode',
         telemetryStorage: Path.resolve(context.extensionPath, '..', 'sonarlint_usage'),
         productName: 'SonarLint VSCode',
         productVersion: VSCode.extensions.getExtension('SonarSource.sonarlint-vscode').packageJSON.version,

--- a/test/samples/.vscode/settings.json
+++ b/test/samples/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "sonarlint.testFilePattern": "**/e2e/samples/**/test/**"
+    "sonarlint.testFilePattern": "**/test/samples/**/test/**"
 }

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -15,10 +15,6 @@ import * as vscode from 'vscode';
 const sampleFolderLocation = '../../../test/samples/';
 
 suite('Extension Test Suite', () => {
-  after(() => {
-    vscode.window.showInformationMessage('All tests done!');
-  });
-
   test('Extension should be present', () => {
     assert.ok(vscode.extensions.getExtension('sonarsource.sonarlint-vscode'));
   });

--- a/test/suite/requirements.test.ts
+++ b/test/suite/requirements.test.ts
@@ -1,0 +1,27 @@
+/* --------------------------------------------------------------------------------------------
+ * SonarLint for VisualStudio Code
+ * Copyright (C) 2017-2019 SonarSource SA
+ * sonarlint@sonarsource.com
+ * Licensed under the LGPLv3 License. See LICENSE.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+import * as assert from 'assert';
+import { parseMajorVersion } from '../../src/requirements';
+
+suite('requirements', () => {
+  test('should parse Java version', function() {
+    //Test boundaries
+    assert.equal(parseMajorVersion(null), 0);
+    assert.equal(parseMajorVersion(''), 0);
+    assert.equal(parseMajorVersion('foo'), 0);
+    assert.equal(parseMajorVersion('version'), 0);
+    assert.equal(parseMajorVersion('version ""'), 0);
+    assert.equal(parseMajorVersion('version "NaN"'), 0);
+
+    //Test the real stuff
+    assert.equal(parseMajorVersion('version "1.7"'), 7);
+    assert.equal(parseMajorVersion('version "1.8.0_151"'), 8);
+    assert.equal(parseMajorVersion('version "9"'), 9);
+    assert.equal(parseMajorVersion('version "9.0.1"'), 9);
+    assert.equal(parseMajorVersion('version "10-ea"'), 10);
+  });
+});


### PR DESCRIPTION
Largely inspired from https://github.com/redhat-developer/vscode-java/commit/6bccceab4eda659d03c149daf17a686f85d70158#diff-baff02b04010a735985f63100efb9fc2

- display detected path
- check if java home ends with `bin`
- opens settings if sonarlint.ls.javaHome preference is invalid