### PR TITLE
fix(dependency): Use correct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "onCommand:SonarLint.UpdateAllBindings",
     "onView:SonarLint.AllRules"
   ],
-  "extensionDependency": [
-    "typescript"
+  "extensionDependencies": [
+    "vscode.typescript-language-features"
   ],
   "contributes": {
     "configuration": {


### PR DESCRIPTION
when https://github.com/SonarSource/sonarlint-vscode/pull/6 was merged, there was a dependency to typescript
https://github.com/SonarSource/sonarlint-vscode/blob/54fec88c8c24a2fde12170b80df956be8663dc57/src/extension.ts#L145

but now dependency is `vscode.typescript-language-features` https://github.com/SonarSource/sonarlint-vscode/blob/b61bc9ad5bb5acda481dce3a8bb59448167aaa93/src/extension.ts#L161

Also use `extensionDependencies` instead of `extensionDependency` which is the appropriate name

> Please review our [contribution guidelines](https://github.com/SonarSource/sonarlint-vscode/blob/master/contributing.md).

FYI this link is invalid

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SLVSCODE) ticket available, please make your commits and pull request start with the ticket ID (SLVSCODE-XXXX)
