### PR TITLE
SLVSCODE-276 Check files are open in an editor before triggering analysis

### DIFF
--- a/scripts/dependencies.json
+++ b/scripts/dependencies.json
@@ -2,7 +2,7 @@
   {
     "groupId": "org.sonarsource.sonarlint.ls",
     "artifactId": "sonarlint-language-server",
-    "version": "2.5.0.47444",
+    "version": "2.5.0.47480",
     "output": "server/sonarlint-ls.jar"
   },
   {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -466,6 +466,7 @@ function installCustomRequestHandlers(context: VSCode.ExtensionContext) {
 
   languageClient.onRequest(protocol.GetJavaConfigRequest.type, fileUri => getJavaConfig(languageClient, fileUri));
   languageClient.onRequest(protocol.ScmCheckRequest.type, fileUri => isIgnoredByScm(fileUri));
+  languageClient.onRequest(protocol.EditorOpenCheck.type, fileUri => isOpenInEditor(fileUri));
   languageClient.onNotification(protocol.ShowNotificationForFirstSecretsIssueNotification.type, () =>
     showNotificationForFirstSecretsIssue(context)
   );
@@ -580,6 +581,10 @@ export async function performIsIgnoredCheck(
   } catch (e) {
     return Promise.resolve(false);
   }
+}
+
+function isOpenInEditor(fileUri: string) {
+  return (VSCode.workspace.textDocuments.some(document => document.uri.toString(true) === fileUri));
 }
 
 async function showAllLocations(issue: protocol.Issue) {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -156,6 +156,10 @@ export namespace NeedCompilationDatabaseRequest {
   export const type = new lsp.NotificationType('sonarlint/needCompilationDatabase');
 }
 
+export namespace EditorOpenCheck {
+  export const type = new lsp.RequestType<string, boolean, void>('sonarlint/isOpenInEditor');
+}
+
 //#endregion
 
 //#region Server side extensions to LSP


### PR DESCRIPTION
See [matching changes on LS](https://github.com/SonarSource/sonarlint-language-server/pull/133)