### PR TITLE
Fix/vs/slvscode update analyzers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.15
-* Update JS/TS/CSS analyzer 9.13.0 -> [10.0.1](https://github.com/SonarSource/SonarJS/releases/tag/10.0.1.20755), support for JavaScript analysis inside HTML files, FN and FP fixes, dependency upgrades
+* Update JS/TS/CSS analyzer 9.13.0 -> [10.0.0](https://github.com/SonarSource/SonarJS/releases/tag/10.0.0.20728) -> [10.0.1](https://github.com/SonarSource/SonarJS/releases/tag/10.0.1.20755), support for JavaScript analysis inside HTML files, FN and FP fixes, dependency upgrades
 * Update CFamily analyzer 6.41.0 -> [6.42.0](https://sonarsource.atlassian.net/issues/?jql=project%20%3D%2010166%20AND%20fixVersion%20%3D%2013995%20ORDER%20BY%20priority%20DESC%2C%20key%20ASC), Support for clang-cl and Microchip compilers
-* Update Python analyzer 3.21 -> [3.25](https://github.com/SonarSource/sonar-python/releases/tag/3.25.0.10992), New quick fixes available, FN and FP fixes
+* Update Python analyzer 3.21 -> [3.25](https://github.com/SonarSource/sonar-python/releases/tag/3.25.0.10992) -> [4.0.0](https://github.com/SonarSource/sonar-python/releases/tag/4.0.0.11155), New quick fixes available, FN and FP fixes
 
 
 ## 3.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.15
-* Update JS/TS/CSS analyzer 9.13.0 -> [10.0.0](https://github.com/SonarSource/SonarJS/releases/tag/10.0.0.20728), support for JavaScript analysis inside HTML files, FN and FP fixes, dependency upgrades
+* Update JS/TS/CSS analyzer 9.13.0 -> [10.0.1](https://github.com/SonarSource/SonarJS/releases/tag/10.0.1.20755), support for JavaScript analysis inside HTML files, FN and FP fixes, dependency upgrades
 
 
 ## 3.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.15
 * Update JS/TS/CSS analyzer 9.13.0 -> [10.0.1](https://github.com/SonarSource/SonarJS/releases/tag/10.0.1.20755), support for JavaScript analysis inside HTML files, FN and FP fixes, dependency upgrades
+* Update CFamily analyzer 6.41.0 -> [6.42.0](https://sonarsource.atlassian.net/issues/?jql=project%20%3D%2010166%20AND%20fixVersion%20%3D%2013995%20ORDER%20BY%20priority%20DESC%2C%20key%20ASC), Support for clang-cl and Microchip compilers
 
 
 ## 3.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.15
 * Update JS/TS/CSS analyzer 9.13.0 -> [10.0.1](https://github.com/SonarSource/SonarJS/releases/tag/10.0.1.20755), support for JavaScript analysis inside HTML files, FN and FP fixes, dependency upgrades
 * Update CFamily analyzer 6.41.0 -> [6.42.0](https://sonarsource.atlassian.net/issues/?jql=project%20%3D%2010166%20AND%20fixVersion%20%3D%2013995%20ORDER%20BY%20priority%20DESC%2C%20key%20ASC), Support for clang-cl and Microchip compilers
+* Update Python analyzer 3.21 -> [3.25](https://github.com/SonarSource/sonar-python/releases/tag/3.25.0.10992), New quick fixes available, FN and FP fixes
 
 
 ## 3.14

--- a/scripts/dependencies.json
+++ b/scripts/dependencies.json
@@ -26,7 +26,7 @@
   {
     "groupId": "org.sonarsource.python",
     "artifactId": "sonar-python-plugin",
-    "version": "3.21.0.10628",
+    "version": "3.25.0.10992",
     "output": "analyzers/sonarpython.jar"
   },
   {

--- a/scripts/dependencies.json
+++ b/scripts/dependencies.json
@@ -8,7 +8,7 @@
   {
     "groupId": "org.sonarsource.javascript",
     "artifactId": "sonar-javascript-plugin",
-    "version": "10.0.0.20728",
+    "version": "10.0.1.20755",
     "output": "analyzers/sonarjs.jar"
   },
   {

--- a/scripts/dependencies.json
+++ b/scripts/dependencies.json
@@ -50,7 +50,7 @@
   {
     "groupId": "com.sonarsource.cpp",
     "artifactId": "sonar-cfamily-plugin",
-    "version": "6.41.0.60884",
+    "version": "6.42.0.61084",
     "output": "analyzers/sonarcfamily.jar",
     "requiresCredentials": true
   }

--- a/scripts/dependencies.json
+++ b/scripts/dependencies.json
@@ -26,7 +26,7 @@
   {
     "groupId": "org.sonarsource.python",
     "artifactId": "sonar-python-plugin",
-    "version": "3.25.0.10992",
+    "version": "4.0.0.11155",
     "output": "analyzers/sonarpython.jar"
   },
   {


### PR DESCRIPTION
Update JS/TS/CSS analyzer 9.13.0 -> 10.0.1
Update CFamily analyzer 6.41.0 -> 6.42.0
Update Python analyzer 3.21.0 ->  4.0.0