### PR TITLE
Add optional argument to configure command

### DIFF
--- a/src/cfamily/cfamily.ts
+++ b/src/cfamily/cfamily.ts
@@ -45,10 +45,11 @@ function tryRelativizeToWorkspaceFolder(filePath: string): [string, vscode.Works
   return [filePath, undefined];
 }
 
-export async function configureCompilationDatabase() {
-  const paths = (await vscode.workspace.findFiles(`**/compile_commands.json`)).filter(path =>
-    fs.existsSync(path.fsPath)
-  );
+export async function configureCompilationDatabase(uri?: vscode.Uri) {
+  const paths =
+    uri instanceof vscode.Uri
+      ? [uri]
+      : (await vscode.workspace.findFiles(`**/compile_commands.json`)).filter(path => fs.existsSync(path.fsPath));
   if (paths.length === 0) {
     vscode.window.showWarningMessage(`No compilation databases were found in the workspace\n 
 [How to generate compile commands](https://github.com/SonarSource/sonarlint-vscode/wiki/C-and-CPP-Analysis)`);


### PR DESCRIPTION
In order for other extensions to programatically configure compile command database location an optional argument has been added to the VS Code command handler function that receives the URI of a compile_commands.json file.

The motive for this change is that my team is working on an extension that manages a development environment in VS Code where several (C/C++) application with multiple build configurations coexists at the same time, all of which have it's own compile_commands.json file. This means that IntelliSense and linting configurations are dynamically changing within a VS Code workspace and our extension is aware of which build configuration is active at all times.

We would like to integrate with the SonarLint extension in way that does not require user interaction in case there are multiple compile_commands.json file is found in the workspace, so we could call the command automatically upon the active configuration changes.

This change doesn't effect functionality of any existing code and is trivial enough that I decided not to touch the unit test code.

Please be aware that I didn't build and test this change due to missing build instructions. It looks like build is impossible due to external dependencies that require a token that is not public.

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SLVSCODE) ticket available, please make your commits and pull request start with the ticket ID (SLVSCODE-XXXX)
