### PR TITLE
BUILD-3523 Fix dogfood.json version is not injected

### DIFF
--- a/.cirrus/cirrus_dogfood_npm
+++ b/.cirrus/cirrus_dogfood_npm
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 source cirrus-env QA
-PROJECT_VERSION=$(npm pkg get version | tr -d \" | sed "s|-SNAPSHOT|+$BUILD_NUMBER|g")
+export PROJECT_VERSION=$(npm pkg get version | tr -d \" | sed "s|-SNAPSHOT|+$BUILD_NUMBER|g")
 
 envsubst '$ARTIFACTORY_URL,$PROJECT_VERSION' <.cirrus/dogfood-template.json > dogfood.json
 jfrog rt u dogfood.json sonarsource-public-builds/org/sonarsource/sonarlint/vscode/sonarlint-vscode/ \


### PR DESCRIPTION
# BUILD-3523 Fix dogfood.json version is not injected

## Changes
* export the variable so that it is available for envsubst

## How was it tested ?
* locally I could reproduce the issue, then I manually defined the PROJECT version and it worked using `export`.