### PR TITLE
NO-JIRA: Don't package IDEA folder into dogfood

### DIFF
--- a/dogfood/.vscodeignore
+++ b/dogfood/.vscodeignore
@@ -10,3 +10,4 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+.idea/**


### PR DESCRIPTION
Currently, the dogfooding extension will contain the `.idea` folder if working with JetBrains WebStorm, this PR removes it.
Baby steps, you know ^^