### PR TITLE
Use a multi-folder workspace to restrict binding changes to a single folder

### DIFF
--- a/its/src/test/javaSuite/java.test.ts
+++ b/its/src/test/javaSuite/java.test.ts
@@ -56,7 +56,7 @@ suite('Java Test Suite', () => {
 
     // Check that we have 2 diagnostics in the right order
     const diags = await waitForSonarLintDiagnostics(fileUri, { atLeastIssues: 2 });
-    assert.deepEqual(diags.map(d => [ d.code, d.message ]), [
+    assert.deepStrictEqual(diags.map(d => [ d.code, d.message ]), [
       [ 'java:S1130', 'Remove the declaration of thrown exception \'edu.marcelo.App$MyException\', as it cannot be thrown from method\'s body.' ],
       [ 'java:S106', 'Replace this use of System.out by a logger.' ]
     ]);
@@ -72,13 +72,13 @@ suite('Java Test Suite', () => {
     ];
     const actualCodeActionTitles = codeActionsResult.filter(c => expectedActionTitles.indexOf(c.title) >= 0).map(c => c.title);
     // Order of code actions is not stable, forcing lexicographic order for assertion
-    actualCodeActionTitles.sort();
-    assert.deepEqual(actualCodeActionTitles, expectedActionTitles);
+    actualCodeActionTitles.sort((a, b) => a.localeCompare(b));
+    assert.deepStrictEqual(actualCodeActionTitles, expectedActionTitles);
 
     // Check that first fix has an edit that can be applied
     const quickFix = codeActionsResult.filter(c => c.title === 'SonarLint: Remove "MyException"')[0] as vscode.CodeAction;
     const fixApplied = await vscode.workspace.applyEdit(quickFix.edit!);
-    assert.equal(fixApplied, true);
+    assert.strictEqual(fixApplied, true);
 
     vscode.commands.executeCommand('workbench.action.closeActiveEditor');
   }).timeout(60 * 1000);
@@ -93,8 +93,8 @@ suite('Java Test Suite', () => {
 
     const diags = await waitForSonarLintDiagnostics(fileUri);
 
-    assert.deepEqual(diags.length, 1);
-    assert.equal(diags[0].message, 'Add at least one assertion to this test case.');
+    assert.deepStrictEqual(diags.length, 1);
+    assert.strictEqual(diags[0].message, 'Add at least one assertion to this test case.');
 
     vscode.commands.executeCommand('workbench.action.closeActiveEditor');
   }).timeout(120 * 1000);

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -27,7 +27,7 @@ function main() {
   const userDataDir = path.resolve(extensionRootPath, 'test', 'userdir');
 
   const launchArgs = [
-    path.resolve(extensionRootPath, 'test/samples'),
+    path.resolve(extensionRootPath, 'test/samples/samples.code-workspace'),
     '--disable-extensions',
     '--disable-workspace-trust',
     `--user-data-dir=${userDataDir}`,

--- a/test/samples/sample-for-bindings/.vscode/settings.json
+++ b/test/samples/sample-for-bindings/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  // This file is kept to restrict scope of binding tests to an empty workspace folder
+}

--- a/test/samples/samples.code-workspace
+++ b/test/samples/samples.code-workspace
@@ -1,0 +1,20 @@
+{
+  "folders": [
+    {
+      "path": "sample-for-bindings"
+    },
+    {
+      "path": "sample-hotspots"
+    },
+    {
+      "path": "sample-js"
+    },
+    {
+      "path": "sample-multi-js"
+    }
+  ],
+  "settings": {
+    "sonarlint.testFilePattern": "**/test/samples/**/test/**",
+    "telemetry.enableTelemetry": false
+  }
+}

--- a/test/suite/autobinding.test.ts
+++ b/test/suite/autobinding.test.ts
@@ -6,9 +6,8 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import { BindingService, ServerProject } from '../../src/connected/binding';
+import { BindingService } from '../../src/connected/binding';
 import {
-  BaseConnection,
   ConnectionSettingsService,
   SonarCloudConnection,
   SonarQubeConnection
@@ -20,7 +19,7 @@ import * as VSCode from 'vscode';
 import { expect } from 'chai';
 import { AutoBindingService, DO_NOT_ASK_ABOUT_AUTO_BINDING_FOR_WS_FLAG } from '../../src/connected/autobinding';
 import { TextEncoder } from 'util';
-import { ListFilesInScopeResponse, FolderUriParams } from '../../src/lsp/protocol';
+import { FolderUriParams, ListFilesInScopeResponse } from '../../src/lsp/protocol';
 
 const CONNECTED_MODE_SETTINGS_SONARQUBE = 'connectedMode.connections.sonarqube';
 const CONNECTED_MODE_SETTINGS_SONARCLOUD = 'connectedMode.connections.sonarcloud';
@@ -109,9 +108,9 @@ suite('Auto Binding Test Suite', () => {
         .get(BINDING_SETTINGS);
       expect(bindingBefore).to.be.empty;
 
-      mockWorkspaceState.updateBindingForFolder([workspaceFolder.uri.toString()]);
+      await mockWorkspaceState.updateBindingForFolder([workspaceFolder.uri.toString()]);
 
-      underTest.checkConditionsAndAttemptAutobinding({ suggestions: {folderUri: [workspaceFolder.uri.toString()]} });
+      await underTest.checkConditionsAndAttemptAutobinding({ suggestions: {folderUri: [workspaceFolder.uri.toString()]} });
 
       const bindingAfter = VSCode.workspace
         .getConfiguration(SONARLINT_CATEGORY, workspaceFolder.uri)
@@ -127,9 +126,9 @@ suite('Auto Binding Test Suite', () => {
         .get(BINDING_SETTINGS);
       expect(bindingBefore).to.be.empty;
 
-      mockWorkspaceState.updateBindingForWs(true);
+      await mockWorkspaceState.updateBindingForWs(true);
 
-      underTest.checkConditionsAndAttemptAutobinding({ suggestions: {} });
+      await underTest.checkConditionsAndAttemptAutobinding({ suggestions: {} });
 
       const bindingAfter = VSCode.workspace
         .getConfiguration(SONARLINT_CATEGORY, workspaceFolder.uri)
@@ -222,11 +221,7 @@ suite('Auto Binding Test Suite', () => {
 });
 
 async function cleanBindings() {
-  return Promise.all(
-    VSCode.workspace.workspaceFolders.map(folder => {
-      return VSCode.workspace
-        .getConfiguration(SONARLINT_CATEGORY, folder.uri)
+  return VSCode.workspace
+        .getConfiguration(SONARLINT_CATEGORY, VSCode.workspace.workspaceFolders[0].uri)
         .update(BINDING_SETTINGS, undefined, VSCode.ConfigurationTarget.WorkspaceFolder);
-    })
-  );
 }

--- a/test/suite/connections.test.ts
+++ b/test/suite/connections.test.ts
@@ -19,7 +19,7 @@ const CONNECTED_MODE_SETTINGS = 'connectedMode.connections';
 const CONNECTED_MODE_SETTINGS_SONARQUBE = 'connectedMode.connections.sonarqube';
 const CONNECTED_MODE_SETTINGS_SONARCLOUD = 'connectedMode.connections.sonarcloud';
 
-const sampleFolderUri = vscode.Uri.file(path.join(__dirname, sampleFolderLocation));
+const sampleFolderUri = vscode.Uri.file(path.join(__dirname, sampleFolderLocation, 'sample-for-bindings'));
 
 const projectKeysToNames = {
   projectKey1: 'Project Name 1',
@@ -126,7 +126,7 @@ suite('Connected Mode Test Suite', () => {
       const remoteProjectChildren = await underTest.getChildren(remoteProjectNode);
       expect(remoteProjectChildren.length).to.equal(1);
       const workspaceFolderNode = remoteProjectChildren[0];
-      expect(workspaceFolderNode.label).to.equal('samples');
+      expect(workspaceFolderNode.label).to.equal('sample-for-bindings');
     });
 
     test('should return two element list when expanding SC and two connections exist', async () => {

--- a/test/suite/util.test.ts
+++ b/test/suite/util.test.ts
@@ -12,7 +12,9 @@ import * as vscode from 'vscode';
 import {
   createAnalysisFilesFromFileUris,
   findFilesInFolder,
-  getFilesMatchedGlobPatterns, getFilesNotMatchedGlobPatterns, getIdeFileExclusions,
+  getFilesMatchedGlobPatterns,
+  getFilesNotMatchedGlobPatterns,
+  getIdeFileExclusions,
   getMasterRegex,
   getQuickPickListItemsForWorkspaceFolders,
   globPatternToRegex,
@@ -68,7 +70,7 @@ suite('util', () => {
 
     const files = await findFilesInFolder(folderUri, cancelToken);
 
-    expect(files.length).to.equal(7);
+    expect(files.length).to.equal(9);
   });
 
   test('should create analysis files from file uris', async () => {
@@ -76,7 +78,7 @@ suite('util', () => {
     const fileUris = await findFilesInFolder(folderUri, cancelToken);
     // @ts-ignore
     const openDocuments: vscode.TextDocument[] = [{
-      uri: fileUris[1],
+      uri: fileUris[2],
       version: 11,
       getText(): string {
         return 'text in editor';
@@ -85,18 +87,18 @@ suite('util', () => {
     }];
     const analysisFiles = await createAnalysisFilesFromFileUris(fileUris, openDocuments, progress, cancelToken);
 
-    expect(fileUris.length).to.equal(7);
-    expect(analysisFiles.length).to.equal(6);
+    expect(fileUris.length).to.equal(9);
+    expect(analysisFiles.length).to.equal(8);
     let inlineAnalysisResult = analysisFiles[0].text.replace(/(\r\n|\n|\r)/gm, '');
     expect(inlineAnalysisResult).to.equal('{    "sonarlint.testFilePattern": "**/test/samples/**/test/**",' +
       '    "telemetry.enableTelemetry": false}');
     expect(analysisFiles[0].uri.endsWith('settings.json')).to.be.true;
     expect(analysisFiles[0].languageId).to.equal('[unknown]');
     expect(analysisFiles[0].version).to.equal(1);
-    expect(analysisFiles[1].text).to.equal('text in editor');
-    expect(analysisFiles[1].uri.endsWith('main.js')).to.be.true;
-    expect(analysisFiles[1].languageId).to.equal('[unknown]');
-    expect(analysisFiles[1].version).to.equal(11);
+    expect(analysisFiles[2].text).to.equal('text in editor');
+    expect(analysisFiles[2].uri.endsWith('main.js')).to.be.true;
+    expect(analysisFiles[2].languageId).to.equal('[unknown]');
+    expect(analysisFiles[2].version).to.equal(11);
   });
 
   test('should generate items for quick pick list from workspace folders', async () => {


### PR DESCRIPTION
Note to reviewers: this does not use the updated SLCORE with additional logs just yet, but it does seem to fix the issues we had previously with cross-test interactions.