### PR TITLE
Fix default password referenced in ssl certificate confirmation dialog

### DIFF
--- a/src/util/showMessage.ts
+++ b/src/util/showMessage.ts
@@ -78,7 +78,7 @@ export async function showSslCertificateConfirmationDialog(cert: SslCertificateC
     Valid to: ${cert.validTo}\n
     ${fingerprints}
     If you trust the certificate, it will be saved in truststore ${cert.truststorePath}\n
-    Default password: changeit\n
+    Default password: sonarlint\n
     Consider removing connection if you don't trust the certificate\n`,
     { modal: true }, dontTrust, trust);
   return dialogResponse === trust;


### PR DESCRIPTION
The default password used for the Sonarlint `truststore.p12` is different to the one referenced in the SSL Certificate Confirmation Dialog.

Correct me if I'm wrong, but the default password is defined here: https://github.com/SonarSource/sonarlint-core/blob/0e7c440fc64a0bae0d82b3fa313e1014363582f7/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/ssl/CertificateStore.java#L25

The dialog box referencing the wrong password had me barking up the wrong tree for an hour or so 😆.