### PR TITLE
SLLS-234 get project names by key

### DIFF
--- a/src/connected/connections.ts
+++ b/src/connected/connections.ts
@@ -161,7 +161,7 @@ export class AllConnectionsTreeDataProvider implements VSCode.TreeDataProvider<C
       return [];
     }
     const allKeys = [...boundProjects.keys()];
-    const keysToNames = await this.client.getRemoteProjectNames(connectionId || DEFAULT_CONNECTION_ID, allKeys);
+    const keysToNames = await this.client.getRemoteProjectNamesByKeys(connectionId || DEFAULT_CONNECTION_ID, allKeys);
     return allKeys.map(k => new RemoteProject(connectionId, k, serverType, keysToNames[k]));
   }
 

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -42,8 +42,8 @@ export class SonarLintExtendedLanguageClient extends LanguageClient {
     return this.sendRequest(protocol.CheckConnection.type, params);
   }
 
-  getRemoteProjectNames(connectionId: string, projectKeys: Array<string>) {
-    return this.sendRequest(protocol.GetRemoteProjectNames.type, { connectionId, projectKeys });
+  getRemoteProjectNamesByKeys(connectionId: string, projectKeys: Array<string>) {
+    return this.sendRequest(protocol.GetRemoteProjectNamesByProjectKeys.type, { connectionId, projectKeys });
   }
 
   onTokenUpdate(connectionId: string, token: string) {

--- a/src/lsp/protocol.ts
+++ b/src/lsp/protocol.ts
@@ -381,9 +381,9 @@ interface GetRemoteProjectNamesParams {
   projectKeys: Array<string>;
 }
 
-export namespace GetRemoteProjectNames {
+export namespace GetRemoteProjectNamesByProjectKeys {
   export const type = new lsp.RequestType<GetRemoteProjectNamesParams, { [key: string]: string }, null>(
-    'sonarlint/getRemoteProjectNames'
+    'sonarlint/getRemoteProjectNamesByProjectKeys'
   );
 }
 

--- a/test/suite/connections.test.ts
+++ b/test/suite/connections.test.ts
@@ -30,7 +30,7 @@ const mockClient = {
   async checkConnection(connectionId: string) {
     return Promise.resolve({ connectionId, success: true });
   },
-  async getRemoteProjectNames(_connectionId, _projectKeys) {
+  async getRemoteProjectNamesByKeys(_connectionId, _projectKeys) {
     return Promise.resolve(projectKeysToNames);
   }
 } as SonarLintExtendedLanguageClient;


### PR DESCRIPTION
With my modifications, users should no longer see a similar `<project not found>` message in the SonarLint Connected Mode view.

![809ebf07-d406-44e7-9718-0a677ee97aa4](https://github.com/SonarSource/sonarlint-vscode/assets/104207951/1dd3d251-bea8-4aeb-835f-ebae4befad1c)


Unfortunately, they will still not be able to find their project in the list when setting up binding. As a workaround, they can always define the binding setting manually under project/.vscode/settings.json, or also use a [shared binding configuration](https://docs.sonarsource.com/sonarlint/vs-code/team-features/connected-mode/#sharing-your-setup).