### PR TITLE
BUILD-5219 use Hashicorp Vault to retrieve secrets

### DIFF
--- a/.github/workflows/credcheck.yml
+++ b/.github/workflows/credcheck.yml
@@ -27,12 +27,14 @@ jobs:
         with:
           secrets: |
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
+            development/kv/data/visualstudio VSCE_TOKEN | VISUALSTUDIO_PAT;
+            development/team/sonarlint/kv/data/openvsx token | OPENVSX_TOKEN;
 
       - name: Check marketplace publisher personal access token
         if: ${{ !cancelled() }}
         env:
           ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
-          VSCE_TOKEN: ${{ secrets.VISUALSTUDIO_PAT }}
+          VSCE_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).VISUALSTUDIO_PAT }}
         working-directory: ./.github/actions/vsce-publish
         run: |
           cp ${GITHUB_WORKSPACE}/.cirrus/.npmrc ./.npmrc
@@ -43,7 +45,7 @@ jobs:
         if: ${{ !cancelled() }}
         env:
           ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
-          OPENVSX_TOKEN: ${{ secrets.OPENVSX_TOKEN }}
+          OPENVSX_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).OPENVSX_TOKEN }}
         working-directory: ./.github/actions/ovsx-publish
         run: |
           cp ${GITHUB_WORKSPACE}/.cirrus/.npmrc ./.npmrc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           secrets: |
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
+            development/kv/data/visualstudio VSCE_TOKEN | VISUALSTUDIO_PAT;
       - name: Install dependencies for vsce-publish
         run: |
           cp ${GITHUB_WORKSPACE}/.cirrus/.npmrc ./.npmrc
@@ -91,7 +92,7 @@ jobs:
         env:
           ARTIFACT_FILE: ${{ steps.download_artifact.outputs.artifactFile }}
           TARGET_PLATFORM: ${{ matrix.platform }}
-          VSCE_TOKEN: ${{ secrets.VISUALSTUDIO_PAT }}
+          VSCE_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).VISUALSTUDIO_PAT }}
         uses: ./.github/actions/vsce-publish
 
   deploy_to_openvsx:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           secrets: |
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
+            development/team/sonarlint/kv/data/openvsx token | OPENVSX_TOKEN;
       - name: Install dependencies for ovsx-publish
         run: |
           cp ${GITHUB_WORKSPACE}/.cirrus/.npmrc ./.npmrc
@@ -155,5 +156,5 @@ jobs:
         id: ovsx_publish
         env:
           ARTIFACT_FILE: ${{ steps.download_artifact.outputs.artifactFile }}
-          OPENVSX_TOKEN: ${{ secrets.OPENVSX_TOKEN }}
+          OPENVSX_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).OPENVSX_TOKEN }}
         uses: ./.github/actions/ovsx-publish


### PR DESCRIPTION
# BUILD-5219 use Hashicorp Vault to retrieve secrets

## Changes
* Retrieve secrets from Hashicorp Vault instead of the one stored in GitHub repository
  That way the new values are used/updated in Vault.
  
  It should resolve issues of [release](https://github.com/SonarSource/sonarlint-vscode/actions/runs/9349453145) 


## How was it tested?
* I triggered credcheck.yml on this same branch https://github.com/SonarSource/sonarlint-vscode/actions/runs/9369027317