### PR TITLE
SLVSCODE-738 show correct default values and setting for actual value in SSL dialog

### DIFF
--- a/scripts/dependencies.json
+++ b/scripts/dependencies.json
@@ -2,7 +2,7 @@
   {
     "groupId": "org.sonarsource.sonarlint.ls",
     "artifactId": "sonarlint-language-server",
-    "version": "3.9.0.75429",
+    "version": "3.10.0.75468",
     "output": "server/sonarlint-ls.jar"
   },
   {

--- a/src/util/showMessage.ts
+++ b/src/util/showMessage.ts
@@ -77,8 +77,9 @@ export async function showSslCertificateConfirmationDialog(cert: SslCertificateC
     Valid from: ${cert.validFrom}\n
     Valid to: ${cert.validTo}\n
     ${fingerprints}
-    If you trust the certificate, it will be saved in truststore ${cert.truststorePath}\n
-    Default password: changeit\n
+    If you trust the certificate, by default it will be saved in truststore '${cert.truststorePath}'\n
+    Default password: sonarlint\n
+    For actual values of truststore path and password, check the 'sonarlint.ls.vmargs' setting.\n
     Consider removing connection if you don't trust the certificate\n`,
     { modal: true }, dontTrust, trust);
   return dialogResponse === trust;


### PR DESCRIPTION
[SLVSCODE-738](https://sonarsource.atlassian.net/browse/SLVSCODE-738)

![Screenshot 2024-08-28 at 14 49 27](https://github.com/user-attachments/assets/4d1ca66c-4df5-46d5-9b27-0f9961dec948)


[SLVSCODE-738]: https://sonarsource.atlassian.net/browse/SLVSCODE-738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ