### PR TITLE
SLLS-226 properly cancel automatic Connection setup

### DIFF
--- a/src/connected/automaticConnectionCancellationError.ts
+++ b/src/connected/automaticConnectionCancellationError.ts
@@ -1,0 +1,6 @@
+export class AutomaticConnectionSetupCancellationError extends Error {
+	constructor(message: string) {
+	  super(message);
+	  this.name = "AutomaticConnectionSetupCancellationError";
+	}
+}


### PR DESCRIPTION
[SLLS-226](https://sonarsource.atlassian.net/browse/SLLS-226)

We should cancel the automatic Connection setup if

- User explicitly cancels it
- User decides to open Connected Mode docs
- We default back to old SonarQube setup (when we don't have access to the token immediately)

Throwing cancellation exception from the client and returning `null` to the Language Server will result in unused tokens being revoked immediately.

[SLLS-226]: https://sonarsource.atlassian.net/browse/SLLS-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ