### PR TITLE
SLVSCODE-880 make sure listFilesInFolder returns on Windows

### DIFF
--- a/src/connected/autobinding.ts
+++ b/src/connected/autobinding.ts
@@ -289,7 +289,7 @@ export class AutoBindingService implements FileSystemSubscriber {
     await this.getContentOfAutobindingFiles(params.folderUri);
     const foundFiles: Array<FoundFileDto> = [
       ...await this.listJsonFilesInDotSonarLint(baseFolderUri),
-      ...this.filesPerConfigScope.get(params.folderUri) || []
+      ...this.filesPerConfigScope.get(baseFolderUri.toString()) || []
     ];
     return { foundFiles };
   }


### PR DESCRIPTION
Cause of the problem: 🥲 
![Screenshot 2024-10-10 at 14 51 41](https://github.com/user-attachments/assets/1259981e-e48a-4e8c-a23f-33ae3459cc92)
![Screenshot 2024-10-10 at 14 51 35](https://github.com/user-attachments/assets/8e7206bd-1f53-4697-a472-5789605c43b1)

Fix has been tested on the Windows VM and it works.