### PR TITLE
SLVSCODE-896 Migrate deprecated cirrus-module v2 to v3

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/SonarSource/cirrus-modules@v2", "load_features")
+load("github.com/SonarSource/cirrus-modules@v3", "load_features")
 
 def main(ctx):
     return load_features(ctx)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,7 +22,7 @@ env:
 
 auto_cancellation: $CIRRUS_BRANCH != $CIRRUS_DEFAULT_BRANCH
 
-eks_container: &CONTAINER_DEFINITION
+container_definition: &CONTAINER_DEFINITION
   dockerfile: .cirrus/Dockerfile
   docker_arguments:
     CIRRUS_AWS_ACCOUNT: ${CIRRUS_AWS_ACCOUNT}
@@ -35,12 +35,11 @@ eks_container: &CONTAINER_DEFINITION
   builder_subnet_id: ${CIRRUS_AWS_SUBNET}
   namespace: default
 
-ec2_instance: &WINVM_DEFINITION
+ec2_instance_definition: &WINVM_DEFINITION
   experimental: true
   image: base-windows-jdk17-v*
   platform: windows
   region: eu-central-1
-  subnet_id: ${CIRRUS_AWS_SUBNET}
   type: t3.xlarge
 
 skip_master_branch_and_allvsix_branch: &SKIP_MASTER_BRANCH_AND_ALLVSIX_BRANCH


### PR DESCRIPTION
[SLVSCODE-896](https://sonarsource.atlassian.net/browse/SLVSCODE-896)

1. Update cirrus-module v2 to v3.
2. Do not call the deprecated AWS feature method parameters `subnet_id`.
3. It is recommended to not use `ec2_instance` or `eks_container` root keys.

[SLVSCODE-896]: https://sonarsource.atlassian.net/browse/SLVSCODE-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ