### PR TITLE
SLVSCODE-877 do not analyze files not open in editor

### DIFF
--- a/scripts/dependencies.json
+++ b/scripts/dependencies.json
@@ -2,7 +2,7 @@
   {
     "groupId": "org.sonarsource.sonarlint.ls",
     "artifactId": "sonarlint-language-server",
-    "version": "3.13.0.75685",
+    "version": "3.13.0.75692",
     "output": "server/sonarlint-ls.jar"
   },
   {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -634,7 +634,10 @@ function installCustomRequestHandlers(context: VSCode.ExtensionContext) {
   languageClient.onNotification(protocol.SubmitNewCodeDefinition.type, newCodeDefinitionForFolderUri => {
     NewCodeDefinitionService.instance.updateNewCodeDefinitionForFolderUri(newCodeDefinitionForFolderUri);
   });
-  languageClient.onNotification(protocol.SuggestConnection.type, (params) => SharedConnectedModeSettingsService.instance.handleSuggestConnectionNotification(params.suggestionsByConfigScopeId))
+  languageClient.onNotification(protocol.SuggestConnection.type, (params) => SharedConnectedModeSettingsService.instance.handleSuggestConnectionNotification(params.suggestionsByConfigScopeId));
+  languageClient.onRequest(protocol.IsOpenInEditor.type, fileUri => {
+    return VSCode.workspace.textDocuments.some(doc => code2ProtocolConverter(doc.uri) === fileUri);
+  });
 }
 
 function updateSonarLintViewContainerBadge() {

--- a/src/lsp/protocol.ts
+++ b/src/lsp/protocol.ts
@@ -753,8 +753,13 @@ export interface ShowFixSuggestionParams {
   textEdits: Change[];
   fileUri: string;
 }
+
 export namespace ShowFixSuggestion {
   export const type = new lsp.NotificationType<ShowFixSuggestionParams>('sonarlint/showFixSuggestion');
+}
+
+export namespace IsOpenInEditor {
+  export const type = new lsp.RequestType<string, boolean, void>('sonarlint/isOpenInEditor');
 }
 
 //#endregion


### PR DESCRIPTION
[SLVSCODE-877](https://sonarsource.atlassian.net/browse/SLVSCODE-877)

SLLS counterpart is [here](https://github.com/SonarSource/sonarlint-language-server/pull/414)

[SLVSCODE-877]: https://sonarsource.atlassian.net/browse/SLVSCODE-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ