### PR TITLE
SLVSCODE-966 improve UX with taint vulnerabilities on file change

### DIFF
--- a/scripts/dependencies.json
+++ b/scripts/dependencies.json
@@ -2,7 +2,7 @@
   {
     "groupId": "org.sonarsource.sonarlint.ls",
     "artifactId": "sonarlint-language-server",
-    "version": "3.15.0.75823",
+    "version": "3.15.0.75834",
     "output": "server/sonarlint-ls.jar"
   },
   {

--- a/src/hotspot/hotspotsTreeDataProvider.ts
+++ b/src/hotspot/hotspotsTreeDataProvider.ts
@@ -9,7 +9,7 @@
 import Timeout = NodeJS.Timeout;
 import * as VSCode from 'vscode';
 import { ProviderResult, TextDocument, ThemeColor, ThemeIcon } from 'vscode';
-import { Diagnostic, PublishHotspotsForFileParams } from '../lsp/protocol';
+import { Diagnostic, PublishDiagnosticsParams } from '../lsp/protocol';
 import { ConnectionSettingsService } from '../settings/connectionsettings';
 import { Commands } from '../util/commands';
 import { getFileNameFromFullPath, getRelativePathFromFullPath, protocol2CodeConverter } from '../util/uri';
@@ -126,7 +126,7 @@ export class AllHotspotsTreeDataProvider implements VSCode.TreeDataProvider<Hots
     await VSCode.commands.executeCommand('setContext', 'SonarLint.Hotspots.ShowMode', showMode);
   }
 
-  async refresh(hotspotsPerFile?: PublishHotspotsForFileParams) {
+  async refresh(hotspotsPerFile?: PublishDiagnosticsParams) {
     if (hotspotsPerFile && hotspotsPerFile.uri) {
       if (hotspotsPerFile.diagnostics.length > 0) {
         this.fileHotspotsCache.set(hotspotsPerFile.uri, hotspotsPerFile.diagnostics);

--- a/src/lsp/protocol.ts
+++ b/src/lsp/protocol.ts
@@ -460,13 +460,17 @@ export interface Diagnostic extends lsp.Diagnostic {
   flows: Flow[];
 }
 
-export interface PublishHotspotsForFileParams {
+export interface PublishDiagnosticsParams {
   uri: string;
   diagnostics: Diagnostic[];
 }
 
 export namespace PublishHotspotsForFile {
-  export const type = new lsp.NotificationType<PublishHotspotsForFileParams>('sonarlint/publishSecurityHotspots');
+  export const type = new lsp.NotificationType<PublishDiagnosticsParams>('sonarlint/publishSecurityHotspots');
+}
+
+export namespace PublishTaintVulnerabilitiesForFile {
+  export const type = new lsp.NotificationType<PublishDiagnosticsParams>('sonarlint/publishTaintVulnerabilities');
 }
 
 export interface ShowHotspotLocationsParams {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -300,3 +300,22 @@ function isOpenInEditor(fileUri: string) {
   const notebookDocumentIsOpen = vscode.workspace.notebookDocuments.some(d => d.uri.toString(false) === codeFileUri);
   return textDocumentIsOpen || notebookDocumentIsOpen;
 }
+
+export function getSeverity(severity: number): vscode.DiagnosticSeverity {
+  const SEVERITY_ERROR = 1;
+  const SEVERITY_WARNING = 2;
+  const SEVERITY_INFORMATION = 3;
+  const SEVERITY_HINT = 4;
+  switch (severity) {
+    case SEVERITY_ERROR:
+      return vscode.DiagnosticSeverity.Error;
+    case SEVERITY_WARNING:
+      return vscode.DiagnosticSeverity.Warning;
+    case SEVERITY_INFORMATION:
+      return vscode.DiagnosticSeverity.Information;
+    case SEVERITY_HINT:
+      return vscode.DiagnosticSeverity.Hint;
+    default:
+      return vscode.DiagnosticSeverity.Warning;
+  }
+}


### PR DESCRIPTION
Before
![before](https://github.com/user-attachments/assets/b4da4a3e-f6fa-4285-9502-5ddf762f6624)

After
![after](https://github.com/user-attachments/assets/c1d33882-2775-4bad-843a-7c65e76b8b3b)

[SLVSCODE-966](https://sonarsource.atlassian.net/browse/SLVSCODE-966)



[SLVSCODE-966]: https://sonarsource.atlassian.net/browse/SLVSCODE-966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ