### PR TITLE
SLVSCODE-1009 URL slug rebranding update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,8 +173,8 @@
 
 ## 3.22
 
-* Add possibility to exclude files from analysis when ***not*** in Connected Mode. [Learn more](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using-sonarlint/file-exclusions)
-* Add focusing on new code in connected mode [Learn more](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using-sonarlint/investigating-issues/#focusing-on-new-code)
+* Add possibility to exclude files from analysis when ***not*** in Connected Mode. [Learn more](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using/file-exclusions)
+* Add focusing on new code in connected mode [Learn more](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using/investigating-issues/#focusing-on-new-code)
 * Update JS/TS/CSS analyzer 10.5.1 -> [10.6.0](https://github.com/SonarSource/SonarJS/releases/tag/10.6.0.22520), FP fixes, QuickFix for S6326, remove S2814 for TypeScript, recommendation to use Node.js 20
 * Update CFamily analyzer 6.48 -> [6.49](https://sonarsource.atlassian.net/issues/?jql=fixVersion%20%3D%2014261%20ORDER%20BY%20created%20ASC), 2 new C++ MISRA 2023 rules
 * Update text and secrets analyzer 2.3.0 -> [2.4.0](https://github.com/SonarSource/sonar-text/releases/tag/2.4.0.2120) -> [2.5.0](https://github.com/SonarSource/sonar-text/releases/tag/2.5.0.2293), 42 new cloud app secrets, FP fixes, analysis time logging
@@ -274,7 +274,7 @@
 
 ## 3.14
 
-* Local detection of [Security Hotspots](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using-sonarlint/security-hotspots/)
+* Local detection of [Security Hotspots](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using/security-hotspots/)
 * Update PHP analyzer 3.25.0 -> [3.26.0](https://github.com/SonarSource/sonar-php/releases/tag/3.26.0.9313) -> [3.27.0](https://github.com/SonarSource/sonar-php/releases/tag/3.27.0.9339) -> [3.27.1](https://github.com/SonarSource/sonar-php/releases/tag/3.27.1.9352), Fix parsing error on namespaces with reserved words
 * Update CFamily analyzer 6.40.0 -> [6.41.0](https://sonarsource.atlassian.net/issues/?jql=project%20%3D%2010166%20AND%20fixVersion%20%3D%2013953%20ORDER%20BY%20priority%20DESC%2C%20key%20ASC), 13 new rules on C++20's "std::format"
 * Update Java analyzer 7.15.0 -> [7.16.0](https://sonarsource.atlassian.net/projects/SONARJAVA/versions/13922/tab/release-report-all-issues), FP fixes, bugfixes, FN fixes

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Out of the box, SonarQube for IDE: VS Code automatically checks your code agains
 - [Terraform rules](https://rules.sonarsource.com/terraform)
 - [TypeScript rules](https://rules.sonarsource.com/typescript)
 
-The full list of supported languages and rules is available in [our docs](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using-sonarlint/rules/).
+The full list of supported languages and rules is available in [our docs](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using/rules/).
 
 ## Requirements
 
@@ -126,7 +126,7 @@ The support for COBOL analysis is only available together with SonarQube Server 
 
 ### Jupyter notebooks
 
-SonarQube for IDE: VS Code supports analysis of Python code inside Jupyter notebooks. See the [documentation](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using-sonarlint/scan-my-project/#jupyter-notebooks) page for details.
+SonarQube for IDE: VS Code supports analysis of Python code inside Jupyter notebooks. See the [documentation](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using/scan-my-project/#jupyter-notebooks) page for details.
 
 ### Injection vulnerabilities specific requirements
 
@@ -138,9 +138,9 @@ More information about security-related rules is available in the SonarQube ([Se
 
 ### Security Hotspots in SonarQube for IDE: VS Code
 
-Local detection of [Security Hotspots](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using-sonarlint/security-hotspots/) is enabled if you are using [Connected Mode](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/team-features/connected-mode/) with SonarQube Server 9.9 or above, or SonarQube Cloud.
+Local detection of [Security Hotspots](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using/security-hotspots/) is enabled if you are using [Connected Mode](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/team-features/connected-mode/) with SonarQube Server 9.9 or above, or SonarQube Cloud.
 
-Please see the [documentation](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using-sonarlint/security-hotspots/) for more details.
+Please see the [documentation](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using/security-hotspots/) for more details.
 
 ### Secrets detection
 
@@ -152,7 +152,7 @@ You can connect SonarQube for IDE to [SonarQube Server](https://www.sonarsource.
 
 While in Connected Mode, SonarQube for IDE receives notifications from SonarQube (Server, Cloud) about your Quality Gate changes and new issues. Notifications can be enabled or disabled from the UI while creating or editing the connection settings.
 
-When running in Connected Mode, and browsing a [Security Hotspot](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using-sonarlint/security-hotspots/), a button will be available offering to open the hotspot in SonarQube for IDE (with SonarQube for IDE already running in VSCode). Limitation: this feature relies on local communication between your web browser and SonarQube for IDE, and consequently is not available in some remote environments such as GitPod, or GitHub CodeSpaces.
+When running in Connected Mode, and browsing a [Security Hotspot](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using/security-hotspots/), a button will be available offering to open the hotspot in SonarQube for IDE (with SonarQube for IDE already running in VSCode). Limitation: this feature relies on local communication between your web browser and SonarQube for IDE, and consequently is not available in some remote environments such as GitPod, or GitHub CodeSpaces.
 
 Connected Mode will also unlock your analysis of these languages:
 

--- a/package.json
+++ b/package.json
@@ -590,7 +590,7 @@
       },
       {
         "view": "SonarLint.SecurityHotspots",
-        "contents": "Please ensure a connection to [SonarQube Server](command:SonarLint.HelpAndFeedbackLinkClicked?%22sonarQubeProductPage%22) 9.9+ or [SonarQube Cloud](command:SonarLint.HelpAndFeedbackLinkClicked?%22sonarCloudProductPage%22) is set up. Detected Security Hotspots will be displayed here. [Learn More](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using-sonarlint/security-hotspots).\n Using the In Whole Folder feature may consume excessive resources depending on the size of your project. Please check the [documentation](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using-sonarlint/security-hotspots/#reporting-security-hotspots-in-the-whole-folder) for recommendations to minimize the impact of a full project analysis."
+        "contents": "Please ensure a connection to [SonarQube Server](command:SonarLint.HelpAndFeedbackLinkClicked?%22sonarQubeProductPage%22) 9.9+ or [SonarQube Cloud](command:SonarLint.HelpAndFeedbackLinkClicked?%22sonarCloudProductPage%22) is set up. Detected Security Hotspots will be displayed here. [Learn More](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using/security-hotspots).\n Using the In Whole Folder feature may consume excessive resources depending on the size of your project. Please check the [documentation](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using/security-hotspots/#reporting-security-hotspots-in-the-whole-folder) for recommendations to minimize the impact of a full project analysis."
       }
     ],
     "walkthroughs": [
@@ -602,7 +602,7 @@
           {
             "id": "SonarLint.inAction",
             "title": "$(rocket) New to SonarQube for VS Code? See it in action",
-            "description": "SonarQube for VS Code supports analysis of 15+ languages including JS/TS, Java, Python, CSS/HTML, C, C++, C#, and [more](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using-sonarlint/rules). SonarQube for VS Code detects issues in all files **open** in the editor. For project-level analysis, check out [SonarQube Cloud](command:SonarLint.HelpAndFeedbackLinkClicked?%22sonarCloudProductPage%22).\n\nThe best way to get started is to see it in action!\n[Open Sample File](command:SonarLint.OpenSample)",
+            "description": "SonarQube for VS Code supports analysis of 15+ languages including JS/TS, Java, Python, CSS/HTML, C, C++, C#, and [more](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using/rules). SonarQube for VS Code detects issues in all files **open** in the editor. For project-level analysis, check out [SonarQube Cloud](command:SonarLint.HelpAndFeedbackLinkClicked?%22sonarCloudProductPage%22).\n\nThe best way to get started is to see it in action!\n[Open Sample File](command:SonarLint.OpenSample)",
             "media": {
               "markdown": "walkthrough/empty.md"
             },

--- a/src/newcode/newCodeDefinitionService.ts
+++ b/src/newcode/newCodeDefinitionService.ts
@@ -56,7 +56,7 @@ export class NewCodeDefinitionService {
               .update('focusOnNewCode', !this.focusOnNewCode, VSCode.ConfigurationTarget.Global);
           }
           if (item.label === `Learn how to deliver clean code with Clean as You Code`) {
-            VSCode.env.openExternal(VSCode.Uri.parse('https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using-sonarlint/investigating-issues/#focusing-on-new-code'));
+            VSCode.env.openExternal(VSCode.Uri.parse('https://docs.sonarsource.com/sonarqube-for-ide/vs-code/using/investigating-issues/#focusing-on-new-code'));
           }
         });
     }));


### PR DESCRIPTION
[SLVSCODE-1009](https://sonarsource.atlassian.net/browse/SLVSCODE-1009)

Part of the rebranding efforts necessitates the update of the URL structure on the Docs website. 
This change reflects part of that update.
A redirect has been added to address links from outside the product.


[SLVSCODE-1009]: https://sonarsource.atlassian.net/browse/SLVSCODE-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ