### PR TITLE
Replace VSCode.Uri.path with fsPath when reading SVG files

### DIFF
--- a/src/rules/rulepanel.ts
+++ b/src/rules/rulepanel.ts
@@ -126,7 +126,7 @@ function renderStandardModeSeverityDetails(ruleType: string, severity: string, r
 }
 
 function fetchSVGIcon(pathToSVG: VSCode.Uri) : string {
-  const svgText = fs.readFileSync(pathToSVG.path, 'utf8');
+  const svgText = fs.readFileSync(pathToSVG.fsPath, 'utf8');
   const parser : DOMParser = new DOMParser();
   const svgDoc = parser.parseFromString(svgText, 'image/svg+xml');
   const svgElement = svgDoc.documentElement;


### PR DESCRIPTION
According to the [documentation](https://github.com/microsoft/vscode-uri/blob/main/src/uri.ts#L200), `fsPath` should be used instead of `path` when reading files on disk. An issue has been reported by users of a fork of SonarLint for VSCode for a custom language, where it was impossible to open the rules description view. Developer console showed this message:
```
ERR [Extension Host] Notification handler 'sonarlint/showRuleDescription' failed with message: ENOENT: no such file or directory, open 'C:\c:\Users\UserName\.vscode\extensions\riversidesoftware.sonarlint-abl-4.14.99002\images\type\code_smell.svg'
```
Note the double `c:\` at the beginning of the path. The problem doesn't happen in all VS Code environments, but switching to the recommended attribute `fsPath` solves the problem. I assume the problem can also happen in the standard SonarLint plugin, hence the PR. 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SLVSCODE) ticket available, please make your commits and pull request start with the ticket ID (SLVSCODE-XXXX)
