### PR TITLE
SLVSCODE-1029 fix order in HotspotResolution enum

### DIFF
--- a/src/lsp/protocol.ts
+++ b/src/lsp/protocol.ts
@@ -185,9 +185,9 @@ export enum HotspotStatus {
 
 export enum ExtendedHotspotStatus {
   ToReview,
-  Safe,
+  Acknowledged,
   Fixed,
-  Acknowledged
+  Safe
 }
 
 export interface RemoteHotspot {

--- a/test/suite/hotspots.test.ts
+++ b/test/suite/hotspots.test.ts
@@ -380,9 +380,9 @@ suite('Hotspots Test Suite', async () => {
   suite('formatStatus', () => {
     test('Should correctly format status', () => {
       assert.strictEqual(formatDetectedHotspotStatus(0), 'To review');
-      assert.strictEqual(formatDetectedHotspotStatus(1), 'Safe');
+      assert.strictEqual(formatDetectedHotspotStatus(1), 'Acknowledged');
       assert.strictEqual(formatDetectedHotspotStatus(2), 'Fixed');
-      assert.strictEqual(formatDetectedHotspotStatus(3), 'Acknowledged');
+      assert.strictEqual(formatDetectedHotspotStatus(3), 'Safe');
     });
   });
 });


### PR DESCRIPTION
[SLVSCODE-1029](https://sonarsource.atlassian.net/browse/SLVSCODE-1029)



[SLVSCODE-1029]: https://sonarsource.atlassian.net/browse/SLVSCODE-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ