### PR TITLE
SLVSCODE-721 change scope of focusOnNewCode setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -362,7 +362,7 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Highlight issues in new code.\n\nFocusing on new code helps you practice [Clean as You Code](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/clean-as-you-code-in-the-ide/).\n\nIn [Connected Mode](https://docs.sonarsource.com/sonarqube-for-ide/vs-code/team-features/connected-mode/) you benefit from a more accurate new code definition based on your SonarQube (Server, Cloud) settings.\n\nWithout Connected Mode (in standalone mode), any code added or changed in the **last 30 days** is considered new code.",
-          "scope": "window"
+          "scope": "machine"
         },
         "sonarlint.earlyAccess.showRegionSelection": {
           "type": "boolean",


### PR DESCRIPTION
[SLVSCODE-721](https://sonarsource.atlassian.net/browse/SLVSCODE-721)

The initial flakiness stems from the fact that we update Global (User) setting, but when reading the setting value, if user has overridden the workspace setting, [it will take priority](https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration).

The original requirements for [standalone mode](https://sonarsource.atlassian.net/browse/MMF-3726) state:
> Focus on new code should be defined globally in SonarLint setting and should be applied to all projects

The original requirements for [Connected mode](https://sonarsource.atlassian.net/browse/MMF-3244) are not clear, but I think it makes sense to apply the same policy for both.


[SLVSCODE-721]: https://sonarsource.atlassian.net/browse/SLVSCODE-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ