### PR TITLE
SLVSCODE-1145 Make sure SQ-IDE output is considered as extension logs

### DIFF
--- a/src/util/logging.ts
+++ b/src/util/logging.ts
@@ -12,7 +12,7 @@ import { isVerboseEnabled } from '../settings/settings';
 let sonarlintOutput: VSCode.OutputChannel;
 
 export function initLogOutput(context: VSCode.ExtensionContext) {
-  sonarlintOutput = VSCode.window.createOutputChannel('SonarQube for IDE');
+  sonarlintOutput = VSCode.window.createOutputChannel('SonarQube for IDE', { log: true });
   context.subscriptions.push(sonarlintOutput);
 }
 


### PR DESCRIPTION
[SLVSCODE-1145](https://sonarsource.atlassian.net/browse/SLVSCODE-1145)

Part of SLVSCODE-1098

Adding this option enables nicer formatting of SonarQube for IDE output (they are considered as logs), and `SonarQube for IDE` also appears as one of the options for `Developer: Export Logs...` command.

![Screenshot 2025-04-28 at 16 09 24](https://github.com/user-attachments/assets/8ce92349-4144-435d-8cbf-8d8c67a2fc2b)
![Screenshot 2025-04-28 at 16 10 35](https://github.com/user-attachments/assets/10068de4-5ad1-4795-88c7-9c4cfbf392a1)


[SLVSCODE-1145]: https://sonarsource.atlassian.net/browse/SLVSCODE-1145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ