### PR TITLE
SLVSCODE-1176 Update Go analyzer 1.22.1 to 1.23.1, update LS for compatibility with Go Enterprise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.23
+
+* Update Go analyzer 1.22.1 -> [1.23](https://sonarsource.atlassian.net/issues/?jql=fixVersion%20=%2019232%20ORDER%20BY%20created%20ASC) -> [1.23.1](https://sonarsource.atlassian.net/issues/?jql=fixVersion%20%3D%2019661%20ORDER%20BY%20created%20ASC)
+
 ## 4.22
 
 * Update Python analyzer 5.3 -> [5.4](https://sonarsource.atlassian.net/issues/?jql=fixVersion%20=%2018803%20ORDER%20BY%20created%20ASC)

--- a/package.json
+++ b/package.json
@@ -967,13 +967,13 @@
     {
       "groupId": "org.sonarsource.sonarlint.ls",
       "artifactId": "sonarlint-language-server",
-      "version": "3.22.0.76129",
+      "version": "3.23.0.76151",
       "output": "server/sonarlint-ls.jar"
     },
     {
       "groupId": "org.sonarsource.go",
       "artifactId": "sonar-go-plugin",
-      "version": "1.22.1.2620",
+      "version": "1.23.1.2838",
       "output": "analyzers/sonargo.jar"
     },
     {


### PR DESCRIPTION
[SLVSCODE-1176](https://sonarsource.atlassian.net/browse/SLVSCODE-1176)

SLVSCODE-1176

[SLVSCODE-1176]: https://sonarsource.atlassian.net/browse/SLVSCODE-1176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ