### PR TITLE
SLVSCODE-1268 security findings view fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 4.26
 
+* Move Taint Vulnerabilities and Security Hotspots to a new, SonarQube view
 * Update Java analyzer 8.15 -> [8.16](https://sonarsource.atlassian.net/issues/?jql=fixVersion%20%3D%2019564%20ORDER%20BY%20created%20ASC) -> [8.17](https://sonarsource.atlassian.net/issues/?jql=fixVersion%20%3D%2021056%20ORDER%20BY%20created%20ASC)
 * Update Go analyzer 1.24 ->[1.25](https://sonarsource.atlassian.net/issues/?jql=fixVersion%20%3D%2020420%20ORDER%20BY%20created%20ASC)
 * Update Java Symbolic Execution analyzer 8.15 -> [8.16](https://sonarsource.atlassian.net/issues/?jql=fixVersion%20%3D%2019727%20ORDER%20BY%20created%20ASC)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -718,8 +718,6 @@ async function getTokenForServer(serverId: string): Promise<string> {
 }
 
 async function showAllLocations(issue: protocol.Issue) {
-  // make sure the view is visible
-  ContextManager.instance.setIssueLocationsContext();
   await secondaryLocationsTree.showAllLocations(issue);
   if (issue.creationDate) {
     const createdAgo = issue.creationDate
@@ -732,6 +730,8 @@ async function showAllLocations(issue: protocol.Issue) {
     issueLocationsView.message = null;
   }
   if (issue.flows.length > 0) {
+    // make sure the view is visible
+    ContextManager.instance.setIssueLocationsContext();
     issueLocationsView.reveal(secondaryLocationsTree.getChildren(null)[0]);
   }
 }

--- a/src/findings/findingsTreeDataProvider.ts
+++ b/src/findings/findingsTreeDataProvider.ts
@@ -58,13 +58,13 @@ const SOURCE_CONFIG: Record<FindingSource, {
     icon: 'security-hotspot',
     iconColor: 'editorInfo.foreground',
     label: 'Security Hotspot',
-    tooltipText: 'This Security Hotspot exists on remote project'
+    tooltipText: 'This Security Hotspot only exists locally'
   },
   [FindingSource.Remote]: {
     icon: 'security-hotspot', 
     iconColor: 'editorInfo.foreground',
     label: 'Security Hotspot',
-    tooltipText: 'This Security Hotspot only exists locally'
+    tooltipText: 'This Security Hotspot exists on remote project'
   },
   [FindingSource.Latest_SonarQube]: {
     label: 'Taint Vulnerability',

--- a/src/findings/findingsTreeDataProvider.ts
+++ b/src/findings/findingsTreeDataProvider.ts
@@ -56,13 +56,13 @@ const SOURCE_CONFIG: Record<FindingSource, {
 }> = {
   [FindingSource.SonarQube]: {
     icon: 'security-hotspot',
-    iconColor: 'editorInfo.foreground',
+    iconColor: 'descriptionForeground',
     label: 'Security Hotspot',
     tooltipText: 'This Security Hotspot only exists locally'
   },
   [FindingSource.Remote]: {
     icon: 'security-hotspot', 
-    iconColor: 'editorInfo.foreground',
+    iconColor: 'descriptionForeground',
     label: 'Security Hotspot',
     tooltipText: 'This Security Hotspot exists on remote project'
   },

--- a/src/newcode/newCodeDefinitionService.ts
+++ b/src/newcode/newCodeDefinitionService.ts
@@ -83,7 +83,7 @@ export class NewCodeDefinitionService {
     }
     const newCodeDefinition = this.getNewCodeDefinition(code2ProtocolConverter(workspaceFolder.uri));
     this.updateStatusBarTooltip(newCodeDefinition);
-    this.updateStatusBarText(this.isSupportedForFile(newCodeDefinition));
+    this.updateStatusBarText();
     this.newCodeStatusBarItem.show();
   }
 
@@ -99,15 +99,8 @@ export class NewCodeDefinitionService {
     this.newCodeStatusBarItem.tooltip = `${newCodeDefinitionMessage}`;
   }
 
-  isSupportedForFile(newCodeDefinition: NewCodeDefinition) {
-    if (newCodeDefinition && this.focusOnNewCode) {
-      return newCodeDefinition.isSupported;
-    }
-    return false;
-  }
-
-  updateStatusBarText(isSupportedForFile: boolean) {
-    const enabledText = this.focusOnNewCode && isSupportedForFile ? 'new code' : 'overall code';
+  updateStatusBarText() {
+    const enabledText = this.focusOnNewCode ? 'new code' : 'overall code';
     this.newCodeStatusBarItem.text = `SonarQube focus: ${enabledText}`;
   }
 


### PR DESCRIPTION
[SLVSCODE-1268](https://sonarsource.atlassian.net/browse/SLVSCODE-1268)

This inconsistency has been there for a long time. It just became more visible now that we have a dedicated button/view to visualise new code focus as well. We could come up with a better long-term improvement later.

![Screenshot 2025-07-07 at 11 00 01](https://github.com/user-attachments/assets/4f0988d0-24dd-4d57-a9fe-d67527e1de49)



[SLVSCODE-1268]: https://sonarsource.atlassian.net/browse/SLVSCODE-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ