### PR TITLE
SLVSCODE-1296 Avoid errors on files outside workspace

### DIFF
--- a/src/findings/findingsTreeDataProvider.ts
+++ b/src/findings/findingsTreeDataProvider.ts
@@ -49,9 +49,10 @@ export class FindingsFileNode extends vscode.TreeItem {
     
     const specifyWorkspaceFolderName = vscode.workspace.workspaceFolders?.length > 1;
     // no need to compute relative path if file is outside any workspace folder
-    this.description = vscode.workspace.workspaceFolders ? getRelativePathFromFullPath(
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(this.resourceUri);
+    this.description = vscode.workspace.workspaceFolders && workspaceFolder ? getRelativePathFromFullPath(
       fileUri,
-      vscode.workspace.getWorkspaceFolder(this.resourceUri),
+      workspaceFolder,
       specifyWorkspaceFolderName
     ) : '';
     
@@ -135,7 +136,7 @@ export class FindingNode extends vscode.TreeItem {
     }
   }
 
-  private getIconForFinding(source: FindingSource): vscode.ThemeIcon | vscode.IconPath {
+  private getIconForFinding(source: FindingSource): vscode.ThemeIcon | { light: vscode.Uri; dark: vscode.Uri } {
     const sourceConfig = SOURCE_CONFIG[source];
     // For security hotspots, use source-specific icons
     if (sourceConfig.icon) {

--- a/src/findings/findingsTreeDataProviderUtil.ts
+++ b/src/findings/findingsTreeDataProviderUtil.ts
@@ -87,7 +87,7 @@ export const SOURCE_CONFIG: Record<
   }
 };
 
-export const impactSeverityToIcon = (impactSeverity: ImpactSeverity): vscode.IconPath => {
+export const impactSeverityToIcon = (impactSeverity: ImpactSeverity): { light: vscode.Uri; dark: vscode.Uri } => {
   switch (impactSeverity) {
     case ImpactSeverity.INFO:
       return {

--- a/test/suite/findingsTreeDataProvider/findingFilters.test.ts
+++ b/test/suite/findingsTreeDataProvider/findingFilters.test.ts
@@ -57,7 +57,17 @@ suite('Findings Tree Data Provider Filtering Test Suite', () => {
     sinon.stub(vscode, 'workspace').value({
       textDocuments: [
         { uri: { toString: () => TEST_OPEN_FILE_URI } } as vscode.TextDocument
-      ]
+      ],
+      getWorkspaceFolder: sinon.stub().returns({
+        uri: vscode.Uri.parse('file:///test'),
+        name: 'test-workspace',
+        index: 0
+      }),
+      workspaceFolders: [{
+        uri: vscode.Uri.parse('file:///test'),
+        name: 'test-workspace',
+        index: 0
+      }]
     });
     sinon.stub(vscode, 'window').value({
       activeTextEditor: {


### PR DESCRIPTION
[SLVSCODE-1296](https://sonarsource.atlassian.net/browse/SLVSCODE-1296)

The main issue was in the `FindingsFileNode` constructor where `vscode.workspace.getWorkspaceFolder(this.resourceUri)` could return `undefined`, but the code was still trying to pass it to `getRelativePathFromFullPath()` which expects a non-null workspace folder.

Fixes the issue:

<img width="831" height="245" alt="image" src="https://github.com/user-attachments/assets/7fbed863-0b37-47a4-9eb7-60f236ca0b2c" />


[SLVSCODE-1296]: https://sonarsource.atlassian.net/browse/SLVSCODE-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ