### PR TITLE
SLVSCODE-1198 refer to SonarQube (Server, Cloud) consistently

### DIFF
--- a/src/connected/autobinding.ts
+++ b/src/connected/autobinding.ts
@@ -24,6 +24,7 @@ import { FileSystemSubscriber } from '../fileSystem/fileSystemSubscriber';
 import { FileSystemServiceImpl } from '../fileSystem/fileSystemServiceImpl'
 import { code2ProtocolConverter } from '../util/uri';
 import { SonarLintExtendedLanguageClient } from '../lsp/client';
+import { ServerType } from './connections';
 
 const AUTOBINDING_THRESHOLD = 1;
 const BIND_ACTION = 'Configure Binding';
@@ -154,14 +155,14 @@ export class AutoBindingService implements FileSystemSubscriber {
     let targetConnection;
     if (sonarCloudConnections.length === 0 && sonarQubeConnections.length === 1) {
       targetConnection = {
-        label: this.computeItemLabel('SonarQube', sonarQubeConnections[0]),
+        label: this.computeItemLabel(ServerType.SonarQube, sonarQubeConnections[0]),
         description: 'SonarQube Server',
         connectionId: this.computeConnectionId(sonarQubeConnections[0]),
         contextValue: 'sonarqubeConnection'
       };
     } else if (sonarQubeConnections.length === 0 && sonarCloudConnections.length === 1) {
       targetConnection = {
-        label: this.computeItemLabel('SonarCloud', sonarCloudConnections[0]),
+        label: this.computeItemLabel(ServerType.SonarCloud, sonarCloudConnections[0]),
         description: 'SonarQube Cloud',
         connectionId: this.computeConnectionId(sonarCloudConnections[0]),
         contextValue: 'sonarcloudConnection'
@@ -170,7 +171,7 @@ export class AutoBindingService implements FileSystemSubscriber {
       const connectionNames = [];
       sonarQubeConnections.forEach(c => {
         connectionNames.push({
-          label: this.computeItemLabel('SonarQube', c),
+          label: this.computeItemLabel(ServerType.SonarQube, c),
           description: 'SonarQube Server',
           connectionId: this.computeConnectionId(c),
           contextValue: 'sonarqubeConnection'
@@ -178,7 +179,7 @@ export class AutoBindingService implements FileSystemSubscriber {
       });
       sonarCloudConnections.forEach(c => {
         connectionNames.push({
-          label: this.computeItemLabel('SonarCloud', c),
+          label: this.computeItemLabel(ServerType.SonarCloud, c),
           description: 'SonarQube Cloud',
           connectionId: this.computeConnectionId(c),
           contextValue: 'sonarcloudConnection'
@@ -192,8 +193,8 @@ export class AutoBindingService implements FileSystemSubscriber {
     return targetConnection;
   }
 
-  private computeItemLabel(serverType: 'SonarQube' | 'SonarCloud', connection) {
-    if (serverType === 'SonarQube') {
+  private computeItemLabel(serverType: ServerType, connection) {
+    if (serverType === ServerType.SonarQube) {
       return connection.connectionId ? connection.connectionId : connection.serverUrl;
     }
     return connection.connectionId ? connection.connectionId : connection.organizationKey;

--- a/src/connected/binding.ts
+++ b/src/connected/binding.ts
@@ -164,7 +164,7 @@ export class BindingService {
     }
 
     if (!serverType) {
-      serverType = contextValue === 'sonarqubeConnection' ? 'SonarQube' : 'SonarCloud';
+      serverType = contextValue === 'sonarqubeConnection' ? ServerType.SonarQube : ServerType.SonarCloud;
     }
     let selectedFolderName;
     if (workspaceFolder) {
@@ -183,7 +183,7 @@ export class BindingService {
   async getBaseServerUrl(connectionId: string, serverType: ServerType): Promise<string> {
     let serverUrlOrOrganizationKey: string;
     let region = undefined;
-    if (serverType === 'SonarQube') {
+    if (serverType === ServerType.SonarQube) {
       serverUrlOrOrganizationKey = (await this.settingsService.loadSonarQubeConnection(connectionId)).serverUrl;
     } else {
       const sonarCloudConnection = await this.settingsService.loadSonarCloudConnection(connectionId);

--- a/src/connected/connections.ts
+++ b/src/connected/connections.ts
@@ -157,7 +157,7 @@ export class AllConnectionsTreeDataProvider implements VSCode.TreeDataProvider<C
       return this.getConnections('__sonarcloud__');
     } else if (element.contextValue === 'sonarqubeConnection' || element.contextValue === 'sonarcloudConnection') {
       const connection = element as Connection;
-      const serverType = element.contextValue === 'sonarqubeConnection' ? 'SonarQube' : 'SonarCloud';
+      const serverType = element.contextValue === 'sonarqubeConnection' ? ServerType.SonarQube : ServerType.SonarCloud;
       return this.getBoundProjects(connection.id, serverType);
     } else if (element.contextValue === 'remoteProject') {
       const project = element as RemoteProject;
@@ -175,7 +175,7 @@ export class AllConnectionsTreeDataProvider implements VSCode.TreeDataProvider<C
     return null;
   }
 
-  async getBoundProjects(connectionId, serverType) {
+  async getBoundProjects(connectionId, serverType: ServerType) {
     const boundProjects = BindingService.instance.getAllBindings().get(connectionId || DEFAULT_CONNECTION_ID);
     if (!boundProjects) {
       return [];
@@ -185,7 +185,7 @@ export class AllConnectionsTreeDataProvider implements VSCode.TreeDataProvider<C
     return allKeys.map(k => new RemoteProject(connectionId, k, serverType, keysToNames[k]));
   }
 
-  getWorkspaceFoldersBoundTo(connectionId, projectKey, serverType) {
+  getWorkspaceFoldersBoundTo(connectionId, projectKey, serverType: ServerType) {
     const boundProjects = BindingService.instance.getAllBindings().get(connectionId || DEFAULT_CONNECTION_ID);
     if (!boundProjects) {
       return [];
@@ -220,4 +220,7 @@ export class AllConnectionsTreeDataProvider implements VSCode.TreeDataProvider<C
   }
 }
 
-export type ServerType = 'SonarQube' | 'SonarCloud';
+export enum ServerType {
+  SonarQube = 'SonarQube Server',
+  SonarCloud = 'SonarQube Cloud'
+}

--- a/src/util/bindingUtils.ts
+++ b/src/util/bindingUtils.ts
@@ -42,7 +42,7 @@ export function serverProjectsToQuickPickItems(serverProjects: BindingSuggestion
 }
 
 export function buildProjectOverviewBaseServerUrl(serverType: ServerType, serverUrlOrOrganizationKey: string, region?: SonarCloudRegion) {
-  if (serverType === 'SonarCloud') {
+  if (serverType === ServerType.SonarCloud) {
    const cloudUrl = region ? SONARCLOUD_REGION_URL_MAP[region] : SONARCLOUD_REGION_URL_MAP['EU'];
     return `${cloudUrl}/project/overview`;
   }

--- a/test/suite/bindingUtils.test.ts
+++ b/test/suite/bindingUtils.test.ts
@@ -8,13 +8,14 @@
 
 import { expect } from 'chai';
 import { buildProjectOverviewBaseServerUrl } from '../../src/util/bindingUtils';
+import { ServerType } from '../../src/connected/connections';
 
 suite('Binding Utils Test Suite', () => {
 
   test('should build base server url', () => {
-    const sqBaseServerUrl = buildProjectOverviewBaseServerUrl('SonarQube', 'serverUrl');
-    const scBaseServerUrl = buildProjectOverviewBaseServerUrl('SonarCloud', 'orgKey');
-    const scBaseServerUrlUS = buildProjectOverviewBaseServerUrl('SonarCloud', 'orgKey', 'US');
+    const sqBaseServerUrl = buildProjectOverviewBaseServerUrl(ServerType.SonarQube, 'serverUrl');
+    const scBaseServerUrl = buildProjectOverviewBaseServerUrl(ServerType.SonarCloud, 'orgKey');
+    const scBaseServerUrlUS = buildProjectOverviewBaseServerUrl(ServerType.SonarCloud, 'orgKey', 'US');
 
     expect(sqBaseServerUrl).to.be.equal('serverUrl/dashboard');
     expect(scBaseServerUrl).to.be.equal('https://sonarcloud.io/project/overview');

--- a/test/suite/bindings.test.ts
+++ b/test/suite/bindings.test.ts
@@ -16,12 +16,13 @@ import {
 
 import * as VSCode from 'vscode';
 import { SonarLintExtendedLanguageClient } from '../../src/lsp/client';
-import { Connection, WorkspaceFolderItem } from '../../src/connected/connections';
+import { Connection, ServerType, WorkspaceFolderItem } from '../../src/connected/connections';
 import * as protocol from '../../src/lsp/protocol';
 import { DEFAULT_CONNECTION_ID } from '../../src/commons';
 import { sleep } from '../testutil';
 import { SharedConnectedModeSettingsService } from '../../src/connected/sharedConnectedModeSettingsService';
 import { selectFirstQuickPickItem } from './commons';
+import { Server } from 'http';
 
 const CONNECTED_MODE_SETTINGS_SONARQUBE = 'connectedMode.connections.sonarqube';
 const SONARLINT_CATEGORY = 'sonarlint';
@@ -145,7 +146,7 @@ suite('Bindings Test Suite', () => {
       expect(updatedBinding).to.deep.equal(TEST_BINDING);
 
       await underTest.deleteBinding(
-        new WorkspaceFolderItem('name', workspaceFolder, TEST_BINDING.connectionId, 'SonarQube')
+        new WorkspaceFolderItem('name', workspaceFolder, TEST_BINDING.connectionId, ServerType.SonarQube)
       );
 
       const deletedBinding = VSCode.workspace
@@ -338,10 +339,10 @@ suite('Bindings Test Suite', () => {
     });
 
     test('should get base server url', async () => {
-      expect(await underTest.getBaseServerUrl('connectionId', 'SonarQube')).to.be.equal(
+      expect(await underTest.getBaseServerUrl('connectionId', ServerType.SonarQube)).to.be.equal(
         'https://next.sonarqube.com/sonarqube/dashboard'
       );
-      expect(await underTest.getBaseServerUrl('connectionId', 'SonarCloud')).to.be.equal(
+      expect(await underTest.getBaseServerUrl('connectionId', ServerType.SonarCloud)).to.be.equal(
         'https://sonarcloud.io/project/overview'
       );
     });


### PR DESCRIPTION
[SLVSCODE-1198](https://sonarsource.atlassian.net/browse/SLVSCODE-1198)



[SLVSCODE-1198]: https://sonarsource.atlassian.net/browse/SLVSCODE-1198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ