### PR TITLE
DO_NOT_MERGE_fix_AZlxXlrTSEbp2GJiCGsK

### DIFF
--- a/src/connected/connections.ts
+++ b/src/connected/connections.ts
@@ -103,7 +103,7 @@ export class AllConnectionsTreeDataProvider implements VSCode.TreeDataProvider<C
         : ConnectionSettingsService.instance.getSonarCloudConnections();
     const connections = await Promise.all(
       connectionsFromSettings.map(async c => {
-        // Display the region prefix in case user is in dogfooding, 
+        // Display the region prefix in case user is in dogfooding,
         // has more than 1 SonarQube Cloud connections, and the region is set
         const regionPrefix = 
           shouldShowRegionSelection() &&

--- a/src/location/locations.ts
+++ b/src/location/locations.ts
@@ -169,11 +169,7 @@ export type LocationTreeItem = IssueItem | ChildItem;
 export class SecondaryLocationsTree implements vscode.TreeDataProvider<LocationTreeItem> {
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<LocationTreeItem | undefined>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
-  private rootItem?: IssueItem;
-
-  constructor() {
-    this.rootItem = null;
-  }
+  private rootItem: IssueItem | null = null;
 
   async showAllLocations(issue: ExtendedClient.Issue) {
     this.rootItem = new IssueItem(issue);


### PR DESCRIPTION
https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=SonarSource_sonarlint-vscode&open=AZlxXlrTSEbp2GJiCGsK

Prefer class field declaration over `this` assignment in constructor for static values

Class properties should be declared as fields rather than assigned in constructors [typescript:S7757](https://sonarcloud.io/organizations/sonarsource/rules?open=typescript%3AS7757&rule_key=typescript%3AS7757)