### PR TITLE
DO_NOT_MERGE_fix_AZlxXlbCSEbp2GJiCGpw

### DIFF
--- a/src/connected/connections.ts
+++ b/src/connected/connections.ts
@@ -103,7 +103,7 @@ export class AllConnectionsTreeDataProvider implements VSCode.TreeDataProvider<C
         : ConnectionSettingsService.instance.getSonarCloudConnections();
     const connections = await Promise.all(
       connectionsFromSettings.map(async c => {
-        // Display the region prefix in case user is in dogfooding, 
+        // Display the region prefix in case user is in dogfooding,
         // has more than 1 SonarQube Cloud connections, and the region is set
         const regionPrefix = 
           shouldShowRegionSelection() &&


### PR DESCRIPTION
Don't use a zero fraction in the number 
Number literals should not have unnecessary decimal points or trailing zeros [typescript:S7748](https://sonarcloud.io/organizations/sonarsource/rules?open=typescript%3AS7748&rule_key=typescript%3AS7748)

https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=SonarSource_sonarlint-vscode&open=AZlxXlbCSEbp2GJiCGpw