### PR TITLE
DO_NOT_MERGE_fix_AZlxXljfSEbp2GJiCGqd

### DIFF
--- a/src/connected/connections.ts
+++ b/src/connected/connections.ts
@@ -103,7 +103,7 @@ export class AllConnectionsTreeDataProvider implements VSCode.TreeDataProvider<C
         : ConnectionSettingsService.instance.getSonarCloudConnections();
     const connections = await Promise.all(
       connectionsFromSettings.map(async c => {
-        // Display the region prefix in case user is in dogfooding, 
+        // Display the region prefix in case user is in dogfooding,
         // has more than 1 SonarQube Cloud connections, and the region is set
         const regionPrefix = 
           shouldShowRegionSelection() &&

--- a/src/findings/findingsTreeDataProvider.ts
+++ b/src/findings/findingsTreeDataProvider.ts
@@ -401,8 +401,7 @@ export class FindingsTreeDataProvider implements vscode.TreeDataProvider<Finding
 
   private getFindingsForNotebook(notebookCellUris: string[]): FindingNode[] {
     return Array.from(notebookCellUris)
-      .map(uri => this.findingsCache.get(uri) || [])
-      .reduce((acc, findings) => acc.concat(findings), []);
+      .flatMap(uri => this.findingsCache.get(uri) || []);
   }
 
   private getFindingsForFile(fileUri: string): FindingNode[] {


### PR DESCRIPTION
<strong>typescript:S7751</strong> - Prefer `Array#flat()` over `Array#reduce()` to flatten an array. • <strong>MINOR</strong> • <a href="https://sonarcloud.io/project/issues?id=SonarSource_sonarlint-vscode&issues=AZlxXljfSEbp2GJiCGqd&open=AZlxXljfSEbp2GJiCGqd">View issue</a>