### PR TITLE
DO NOT MERGE: fix_AZjrywZIDdobEpXmdMg1_typescript:S1128

### DIFF
--- a/src/connected/sharedConnectedModeSettingsService.ts
+++ b/src/connected/sharedConnectedModeSettingsService.ts
@@ -16,7 +16,6 @@ import { TextEncoder } from 'util';
 import * as path from 'path';
 import { FileSystemSubscriber } from '../fileSystem/fileSystemSubscriber';
 import { FileSystemServiceImpl } from '../fileSystem/fileSystemServiceImpl';
-import { SonarCloudRegion } from '../settings/connectionsettings';
 import { sonarCloudRegionToLabel } from '../util/util';
 import { shouldShowRegionSelection } from '../settings/settings';
 import { CustomQuickPickItem, deduplicateSuggestions } from '../util/connectionSuggestionUtils';


### PR DESCRIPTION
**Rule:** `typescript:S1128`
**Severity:** MINOR
**Issue description:** `Remove this unused import of 'SonarCloudRegion'.`


Remove unused SonarCloudRegion import