### PR TITLE
DO NOT MERGE: fix_AZlxXli8SEbp2GJiCGqR_typescript:S7770

### DIFF
--- a/src/scm/scm.ts
+++ b/src/scm/scm.ts
@@ -238,7 +238,7 @@ export async function getSubmodulesPaths(gitPath: string, repoPath: string): Pro
     }
 
     const raw = result.stdout;
-    return raw.split('\n').map(value => value.split(/\s/g)[1]).filter(value => value);
+    return raw.split('\n').map(value => value.split(/\s/g)[1]).filter(Boolean);
   } catch (e) {
     logNoSubmodulesFound(repoPath, e);
     return Promise.resolve([]);


### PR DESCRIPTION
**Rule:** `typescript:S7770`
**Severity:** MINOR
**Issue description:** `arrow function is equivalent to `Boolean`. Use `Boolean` directly.`


Replace arrow function with Boolean for filtering truthy values