### PR TITLE
DO NOT MERGE: fix_AZlxXljfSEbp2GJiCGqd_typescript:S7751

### DIFF
--- a/src/findings/findingsTreeDataProvider.ts
+++ b/src/findings/findingsTreeDataProvider.ts
@@ -401,8 +401,7 @@ export class FindingsTreeDataProvider implements vscode.TreeDataProvider<Finding
 
   private getFindingsForNotebook(notebookCellUris: string[]): FindingNode[] {
     return Array.from(notebookCellUris)
-      .map(uri => this.findingsCache.get(uri) || [])
-      .reduce((acc, findings) => acc.concat(findings), []);
+      .flatMap(uri => this.findingsCache.get(uri) || []);
   }
 
   private getFindingsForFile(fileUri: string): FindingNode[] {


### PR DESCRIPTION
**Rule:** `typescript:S7751`
**Severity:** MINOR
**Issue description:** `Prefer `Array#flat()` over `Array#reduce()` to flatten an array.`


Replace Array#reduce() with Array#flat() for array flattening