### PR TITLE
DO NOT MERGE: fix_AZlxXlnPSEbp2GJiCGq-_typescript:S7745

### DIFF
--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -144,7 +144,7 @@ export function allTrue(values: boolean[]) {
 }
 
 export function allFalse(values: boolean[]) {
-  return values.length === 0 || values.every(negate(identity));
+  return values.every(negate(identity));
 }
 
 export function toggleRule(level: ExtendedServer.ConfigLevel) {


### PR DESCRIPTION
**Rule:** `typescript:S7745`
**Severity:** MINOR
**Issue description:** `The empty check is useless as `Array#every()` returns `true` for an empty array.`


Remove redundant length check before Array#every()