### PR TITLE
DO NOT MERGE: fix_AZlxXlrTSEbp2GJiCGsK_typescript:S7757

### DIFF
--- a/src/location/locations.ts
+++ b/src/location/locations.ts
@@ -169,11 +169,7 @@ export type LocationTreeItem = IssueItem | ChildItem;
 export class SecondaryLocationsTree implements vscode.TreeDataProvider<LocationTreeItem> {
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<LocationTreeItem | undefined>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
-  private rootItem?: IssueItem;
-
-  constructor() {
-    this.rootItem = null;
-  }
+  private rootItem?: IssueItem = null;
 
   async showAllLocations(issue: ExtendedClient.Issue) {
     this.rootItem = new IssueItem(issue);


### PR DESCRIPTION
**Rule:** `typescript:S7757`
**Severity:** MINOR
**Issue description:** `Prefer class field declaration over `this` assignment in constructor for static values.`


Move this.rootItem = null to class field declaration