### PR TITLE
DO NOT MERGE: fix_AZlxXlioSEbp2GJiCGqI_typescript_S7718

### DIFF
--- a/src/connected/sharedConnectedModeSettingsService.ts
+++ b/src/connected/sharedConnectedModeSettingsService.ts
@@ -257,7 +257,7 @@ export class SharedConnectedModeSettingsService implements FileSystemSubscriber 
 function tryGetWorkspaceFolder(configScopeId: string) {
   try {
     return vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(configScopeId));
-  } catch (notAuri) {
+  } catch (error_) {
     return undefined;
   }
 }


### PR DESCRIPTION
## 🔧 SonarQube Issue Fix

**Rule:** `typescript:S7718`
**Severity:** MINOR
**Issue description:** `The catch parameter 'notAuri' should be named 'error_'.`

### 📋 Fix Description

Rename catch parameter notAuri to error_

Made with [Cursor](https://cursor.com)