### PR TITLE
NO-JIRA [DO NOT MERGE] fix_AZlxXlioSEbp2GJiCGqI

### DIFF
--- a/src/connected/sharedConnectedModeSettingsService.ts
+++ b/src/connected/sharedConnectedModeSettingsService.ts
@@ -257,7 +257,7 @@ export class SharedConnectedModeSettingsService implements FileSystemSubscriber 
 function tryGetWorkspaceFolder(configScopeId: string) {
   try {
     return vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(configScopeId));
-  } catch (notAuri) {
+  } catch (error_) {
     return undefined;
   }
 }


### PR DESCRIPTION
## SonarQube Issue Fix

**Rule:** typescript:S7718 (MINOR)
**Message:** The catch parameter `notAuri` should be named `error_`.

[View issue in SonarCloud](https://sonarcloud.io/project/issues?id=SonarSource_sonarlint-vscode&issues=AZlxXlioSEbp2GJiCGqI&open=AZlxXlioSEbp2GJiCGqI)