### PR TITLE
NO-JIRA [DO NOT MERGE] [CLAUDE-STATIC] fix_AZlxXli8SEbp2GJiCGqR

### DIFF
--- a/src/scm/scm.ts
+++ b/src/scm/scm.ts
@@ -238,7 +238,7 @@ export async function getSubmodulesPaths(gitPath: string, repoPath: string): Pro
     }
 
     const raw = result.stdout;
-    return raw.split('\n').map(value => value.split(/\s/g)[1]).filter(value => value);
+    return raw.split('\n').map(value => value.split(/\s/g)[1]).filter(Boolean);
   } catch (e) {
     logNoSubmodulesFound(repoPath, e);
     return Promise.resolve([]);


### PR DESCRIPTION
## SonarQube Issue Fix

**Rule:** typescript:S7770 (MINOR)
**Message:** arrow function is equivalent to `Boolean`. Use `Boolean` directly.

[View issue in SonarCloud](https://sonarcloud.io/project/issues?id=SonarSource_sonarlint-vscode&issues=AZlxXli8SEbp2GJiCGqR&open=AZlxXli8SEbp2GJiCGqR)