### PR TITLE
NO-JIRA [DO NOT MERGE] [CLAUDE-STATIC] fix_AZlxXlnPSEbp2GJiCGq-

### DIFF
--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -144,7 +144,7 @@ export function allTrue(values: boolean[]) {
 }
 
 export function allFalse(values: boolean[]) {
-  return values.length === 0 || values.every(negate(identity));
+  return values.every(negate(identity));
 }
 
 export function toggleRule(level: ExtendedServer.ConfigLevel) {


### PR DESCRIPTION
## SonarQube Issue Fix

**Rule:** typescript:S7745 (MINOR)
**Message:** The empty check is useless as `Array#every()` returns `true` for an empty array.

[View issue in SonarCloud](https://sonarcloud.io/project/issues?id=SonarSource_sonarlint-vscode&issues=AZlxXlnPSEbp2GJiCGq-&open=AZlxXlnPSEbp2GJiCGq-)