### PR TITLE
SLVSCODE-1606 DO_NOT_MERGE_fix_AZlxXlnPSEbp2GJiCGq-

### DIFF
--- a/src/connected/connections.ts
+++ b/src/connected/connections.ts
@@ -103,7 +103,7 @@ export class AllConnectionsTreeDataProvider implements VSCode.TreeDataProvider<C
         : ConnectionSettingsService.instance.getSonarCloudConnections();
     const connections = await Promise.all(
       connectionsFromSettings.map(async c => {
-        // Display the region prefix in case user is in dogfooding, 
+        // Display the region prefix in case user is in dogfooding,
         // has more than 1 SonarQube Cloud connections, and the region is set
         const regionPrefix = 
           shouldShowRegionSelection() &&

--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -144,7 +144,7 @@ export function allTrue(values: boolean[]) {
 }
 
 export function allFalse(values: boolean[]) {
-  return values.length === 0 || values.every(negate(identity));
+  return values.every(negate(identity));
 }
 
 export function toggleRule(level: ExtendedServer.ConfigLevel) {


### PR DESCRIPTION
<strong>typescript:S7745</strong> - The empty check is useless as `Array#every()` returns `true` for an empty array. • <strong>MINOR</strong> • <a href="https://sonarcloud.io/project/issues?id=SonarSource_sonarlint-vscode&issues=AZlxXlnPSEbp2GJiCGq-&open=AZlxXlnPSEbp2GJiCGq-">View issue</a>