### PR TITLE
SLVSCODE-1607 DO_NOT_MERGE_fix_AZlxXlioSEbp2GJiCGqI

### DIFF
--- a/src/connected/connections.ts
+++ b/src/connected/connections.ts
@@ -103,7 +103,7 @@ export class AllConnectionsTreeDataProvider implements VSCode.TreeDataProvider<C
         : ConnectionSettingsService.instance.getSonarCloudConnections();
     const connections = await Promise.all(
       connectionsFromSettings.map(async c => {
-        // Display the region prefix in case user is in dogfooding, 
+        // Display the region prefix in case user is in dogfooding,
         // has more than 1 SonarQube Cloud connections, and the region is set
         const regionPrefix = 
           shouldShowRegionSelection() &&

--- a/src/connected/sharedConnectedModeSettingsService.ts
+++ b/src/connected/sharedConnectedModeSettingsService.ts
@@ -257,7 +257,7 @@ export class SharedConnectedModeSettingsService implements FileSystemSubscriber 
 function tryGetWorkspaceFolder(configScopeId: string) {
   try {
     return vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(configScopeId));
-  } catch (notAuri) {
+  } catch (error_) {
     return undefined;
   }
 }


### PR DESCRIPTION
<strong>typescript:S7718</strong> - The catch parameter `notAuri` should be named `error_`. • <strong>MINOR</strong> • <a href="https://sonarcloud.io/project/issues?id=SonarSource_sonarlint-vscode&issues=AZlxXlioSEbp2GJiCGqI&open=AZlxXlioSEbp2GJiCGqI">View issue</a>