### PR TITLE
SLVSCODE-1716 Update release-github-actions to 1.5.9

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: SonarSource/release-github-actions/.github/workflows/ide-automated-release.yml@f89f99a2c6b3dad90646074261469e94297570bc # 1.5.8
+    uses: SonarSource/release-github-actions/.github/workflows/ide-automated-release.yml@706e44289960d7768dc6f953bc1c0df003e812cb # 1.5.9
     permissions:
       statuses: read
       id-token: write


### PR DESCRIPTION
Using fixed GitHub Action with correct release title

https://github.com/SonarSource/release-github-actions/commit/706e44289960d7768dc6f953bc1c0df003e812cb