### PR TITLE
SLVSCODE-1707 SLVSCODE-1710 SLVSCODE-1727 SLVSCODE-1729 5.3 analyzer updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -337,6 +337,34 @@ jobs:
       - name: Prepare xvfb and ffmpeg
         run: mise run install-system-deps
 
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@87b7050bc53ea08284295505d98d2aa94301e852 # v4
+        with:
+          dotnet-version: '8.0.406'
+
+      - name: Pin dotnet for integration tests
+        run: |
+          echo "DOTNET_MULTILEVEL_LOOKUP=0" >> "$GITHUB_ENV"
+          echo "DOTNET_ROOT=/usr/share/dotnet" >> "$GITHUB_ENV"
+          echo "/usr/share/dotnet" >> "$GITHUB_PATH"
+          # OmniSharp 1.39.x cannot use MSBuild from .NET 9/10 SDKs shipped on ubuntu-latest runners.
+          shopt -s nullglob
+          for sdk_dir in /usr/share/dotnet/sdk/9.* /usr/share/dotnet/sdk/10.*; do
+            sudo rm -rf "$sdk_dir"
+          done
+          for runtime_dir in \
+            /usr/share/dotnet/shared/Microsoft.NETCore.App/9.* \
+            /usr/share/dotnet/shared/Microsoft.NETCore.App/10.* \
+            /usr/share/dotnet/shared/Microsoft.AspNetCore.App/9.* \
+            /usr/share/dotnet/shared/Microsoft.AspNetCore.App/10.*; do
+            sudo rm -rf "$runtime_dir"
+          done
+          for sdk_dir in /usr/share/dotnet/sdk/*; do
+            if [ "$(basename "$sdk_dir")" != "8.0.406" ]; then
+              sudo rm -rf "$sdk_dir"
+            fi
+          done
+
       - name: Download VSIX artifact
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
@@ -352,6 +380,7 @@ jobs:
           npm ci
           npm run compile
           npm run prepare
+          dotnet build its/samples/sample-cs/CSSample/CSSample.csproj
           cd its
           npm ci
 

--- a/its/samples/sample-cs/CSSample/CSSample.csproj
+++ b/its/samples/sample-cs/CSSample/CSSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/its/samples/sample-cs/global.json
+++ b/its/samples/sample-cs/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.406",
+    "rollForward": "latestPatch",
+    "allowPrerelease": false
+  }
+}

--- a/its/src/test/common/util.ts
+++ b/its/src/test/common/util.ts
@@ -43,7 +43,7 @@ export function dumpLogOutput() {
 }
 
 function getSonarLintDiagnostics(fileUri: vscode.Uri) {
-  return vscode.languages.getDiagnostics(fileUri).filter(d => d.source === 'sonarqube');
+  return vscode.languages.getDiagnostics(fileUri).filter(d => d.source?.startsWith('sonarqube'));
 }
 
 function sleep(ms: number): Promise<void> {

--- a/its/src/test/csharpsuite/csharp.test.ts
+++ b/its/src/test/csharpsuite/csharp.test.ts
@@ -21,7 +21,7 @@ suite('CSharp Test Suite', () => {
     this.timeout(30 * 1000);
     vscode.window.showInformationMessage('Start CSharp tests.');
     vscode.commands.executeCommand('workbench.panel.markers.view.focus');
-  
+
     await activateAndShowOutput();
   });
 
@@ -30,7 +30,6 @@ suite('CSharp Test Suite', () => {
     const document = await vscode.workspace.openTextDocument(fileUri);
     await vscode.window.showTextDocument(document);
 
-    // Check that we have the expected diagnostic
     const diags = await waitForSonarLintDiagnostics(fileUri, { atLeastIssues: 1, timeoutMillis: 45_000 });
     assert.deepEqual(
       diags.map(d => [d.code, d.message]),


### PR DESCRIPTION
Analyzer updates for the 5.3 release.

- SLVSCODE-1707 Update php to 3.57.0.15976
- SLVSCODE-1710 Update xml to 2.17.0.7895
- SLVSCODE-1727 Update go to 1.38.0.6335
- SLVSCODE-1729 Update javascript to 12.5.0.41048

`package-lock.json` regenerated from scratch (`rm -f package-lock.json && npm install`).

----
## Summary by Gitar

- **CI/CD configuration:**
  - Force use of .NET SDK `8.0.406` by removing newer SDK/runtime versions in GitHub Actions.
  - Added `global.json` and updated `CSSample.csproj` to `Library` output to ensure compatibility.
- **Integration testing:**
  - Updated `getSonarLintDiagnostics` to filter by diagnostic source prefix for improved robustness.
  - Enforced `dotnet build` of sample projects during CI test preparation.

<sub>This will update automatically on new commits.</sub>