### PR TITLE
SLVSCODE-1744 Fix C# ITs on GitHub Actions by isolating .NET SDK 8.0.406 for qa-tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -337,6 +337,19 @@ jobs:
       - name: Prepare xvfb and ffmpeg
         run: mise run install-system-deps
 
+      - name: Setup .NET SDK
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet-it
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: '8.0.406'
+
+      - name: Pin dotnet for integration tests
+        run: |
+          echo "DOTNET_MULTILEVEL_LOOKUP=0" >> "$GITHUB_ENV"
+          echo "DOTNET_ROOT=${{ runner.tool_cache }}/dotnet-it" >> "$GITHUB_ENV"
+          echo "${{ runner.tool_cache }}/dotnet-it" >> "$GITHUB_PATH"
+
       - name: Download VSIX artifact
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:

--- a/its/src/test/common/util.ts
+++ b/its/src/test/common/util.ts
@@ -43,7 +43,7 @@ export function dumpLogOutput() {
 }
 
 function getSonarLintDiagnostics(fileUri: vscode.Uri) {
-  return vscode.languages.getDiagnostics(fileUri).filter(d => d.source === 'sonarqube');
+  return vscode.languages.getDiagnostics(fileUri).filter(d => d.source?.startsWith('sonarqube'));
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
----
## Summary by Gitar

- **CI Configuration:**
  - Added a dedicated .NET SDK 8.0.406 installation to `build.yml` for integration test isolation.
  - Set `DOTNET_MULTILEVEL_LOOKUP` to 0 and configured `DOTNET_ROOT` to prevent external SDK interference.
- **Integration Tests:**
  - Updated `getSonarLintDiagnostics` in `util.ts` to use a prefix match for the `sonarqube` diagnostic source.

<sub>This will update automatically on new commits.</sub>