### PR TITLE
PREQ-6514 Add explicit sonar.projectKey for SCA check discovery

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,4 @@
+sonar.projectKey=org.sonarsource.sonarlint.vscode:sonarlint-vscode
 sonar.sources=src,webview-ui,styles,build-sonarlint
 sonar.tests=test,its/src
 sonar.exclusions=test/**, build/**, out/**, out-cov/**, coverage/**, node_modules/**, **/node_modules/**, **/its/**, **/dogfood/**


### PR DESCRIPTION
## Summary
Declares `sonar.projectKey=org.sonarsource.sonarlint.vscode:sonarlint-vscode` in `sonar-project.properties` so the `verify-sca` / `check-sca` discovery succeeds.

## Why
`check-sca` fails on this repo's PRs with `Could not discover any SonarQube project keys` ([PREQ-6514](https://sonarsource.atlassian.net/browse/PREQ-6514), e.g. [run 27674543768](https://github.com/SonarSource/sonarlint-vscode/actions/runs/27674543768/job/81846552377)).

Root cause: `check-sca.sh` runs under `set -euo pipefail`. Its `discover_project_keys()` parses `sonar-project.properties` for `sonar.projectKey` with an unguarded `grep` pipeline. This repo's `sonar-project.properties` had **no** `sonar.projectKey` line, so `grep` exits non-zero and `set -e` aborts the function **before** it reaches the `.github/repo-metadata.yaml`, `.sonarlint/connectedMode.json`, and `GITHUB_REPOSITORY` fallbacks — so nothing is discovered even though those sources already contain the key.

Declaring the key explicitly makes the first parse succeed, so discovery completes. This is the immediate unblock; the durable fix (guarding the parse so discovery never aborts) is tracked for `SonarSource/ci-github-actions` `check-sca.sh`.

## Test plan
- [ ] `verify-sca` / `SCA Check` passes on this PR.
- [ ] Confirm the discovered project key resolves on the SonarQube platform where the project is analyzed.

[PREQ-6514]: https://sonarsource.atlassian.net/browse/PREQ-6514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ