### PR TITLE
SLVSCODE-1787 Update the 'sonarqube-scanner' dependency to 4.3.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "mocha": "^11.7.5",
         "mocha-multi-reporters": "^1.5.1",
         "prettier": "^3.7.4",
-        "sonarqube-scanner": "^4.3.6",
+        "sonarqube-scanner": "^4.3.8",
         "stream": "^0.0.3",
         "through2": "^4.0.2",
         "ts-loader": "^9.5.4",
@@ -2727,14 +2727,15 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.17.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -2800,9 +2801,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.7.2",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/bare-fs/-/bare-fs-4.7.2.tgz",
-      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "version": "4.7.3",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/bare-fs/-/bare-fs-4.7.3.tgz",
+      "integrity": "sha512-xRgplks8SvcKkdlv2M6Z2LZmRsmqd+x0nXXGXeMEjwdibj1HSDrlnqBRLeYdMvsgCox7Bq0e+DHwfczOfsn6IA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8012,13 +8013,13 @@
       }
     },
     "node_modules/properties-file": {
-      "version": "4.0.0",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/properties-file/-/properties-file-4.0.0.tgz",
-      "integrity": "sha512-VWnuWVVQIeYPdJwWfBVu6/SQExpAliGkY8Bq58pHHPJHgD4THXlJfsc+qC41+62iV4WNwQhmrxbqpEXIvIMOmw==",
+      "version": "5.0.5",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/properties-file/-/properties-file-5.0.5.tgz",
+      "integrity": "sha512-Gfi6UgMENAzww1P4hloKhLIQxqcYmUS5z+Lhm/jmFV+ushbE416NalT42oEfJbF9vd0a02B3AaLHiQGmNSQ9EA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=0.4.0"
       }
     },
     "node_modules/proxy-from-env": {
@@ -8998,22 +8999,22 @@
       }
     },
     "node_modules/sonarqube-scanner": {
-      "version": "4.3.6",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/sonarqube-scanner/-/sonarqube-scanner-4.3.6.tgz",
-      "integrity": "sha512-gRtTf11UXl5SqXrRKzXagdRh06v8n2qXAypEhmlTOFCdAUlR4TboPzYClMFFT7NCZq5jKZSyN2mk5jj01RgVVQ==",
+      "version": "4.3.8",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/sonarqube-scanner/-/sonarqube-scanner-4.3.8.tgz",
+      "integrity": "sha512-mkxxVmUJB5ammq4y8RJSWuW79MdV0tW5Bpi/rzi7hytu1ahyQwFdSoBlAoH1UsLSvfd1iM5R+5sjZbWlaOhGhA==",
       "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
         "adm-zip": "0.5.17",
-        "axios": "1.15.0",
+        "axios": "1.17.0",
         "commander": "14.0.3",
         "hpagent": "1.2.0",
         "node-forge": "1.4.0",
-        "properties-file": "4.0.0",
+        "properties-file": "5.0.5",
         "proxy-from-env": "2.1.0",
-        "semver": "7.7.4",
+        "semver": "7.8.4",
         "slugify": "1.6.9",
-        "tar-stream": "3.1.8"
+        "tar-stream": "3.2.0"
       },
       "bin": {
         "sonar": "bin/sonar-scanner.js",
@@ -9044,9 +9045,9 @@
       }
     },
     "node_modules/sonarqube-scanner/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9057,9 +9058,9 @@
       }
     },
     "node_modules/sonarqube-scanner/node_modules/tar-stream": {
-      "version": "3.1.8",
-      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/tar-stream/-/tar-stream-3.1.8.tgz",
-      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "version": "3.2.0",
+      "resolved": "https://repox.jfrog.io/artifactory/api/npm/npm/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1480,7 +1480,7 @@
     "mocha": "^11.7.5",
     "mocha-multi-reporters": "^1.5.1",
     "prettier": "^3.7.4",
-    "sonarqube-scanner": "^4.3.6",
+    "sonarqube-scanner": "^4.3.8",
     "stream": "^0.0.3",
     "through2": "^4.0.2",
     "ts-loader": "^9.5.4",


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency updates:**
  - Bumped `sonarqube-scanner` from `4.3.6` to `4.3.8` in `package.json` and `package-lock.json`.

<sub>This will update automatically on new commits.</sub>