### PR TITLE
SLVSCODE-1816 Update sonarlint-language-server to 5.6.0.78576

### DIFF
--- a/package.json
+++ b/package.json
@@ -1494,7 +1494,7 @@
     {
       "groupId": "org.sonarsource.sonarlint.ls",
       "artifactId": "sonarlint-language-server",
-      "version": "5.5.0.78541",
+      "version": "5.6.0.78576",
       "output": "server/sonarlint-ls.jar"
     },
     {


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependencies:**
    - Updated `sonarlint-language-server` from `5.5.0.78541` to `5.6.0.78576` in `package.json`.

<sub>This will update automatically on new commits.</sub>