### PR TITLE
SLVSCODE-1831 Stop sending VS Code's own device id in telemetry

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -213,8 +213,7 @@ export async function activate(context: VSCode.ExtensionContext) {
             remoteName: cleanRemoteName(VSCode.env.remoteName),
             uiKind: VSCode.UIKind[VSCode.env.uiKind],
             installTime,
-            isTelemetryEnabled: VSCode.env.isTelemetryEnabled,
-            ...(VSCode.env.isTelemetryEnabled && { machineId: VSCode.env.machineId })
+            isTelemetryEnabled: VSCode.env.isTelemetryEnabled
           },
         },
         enableNotebooks: true,


### PR DESCRIPTION
----
## Summary by Gitar

- **Telemetry updates:**
    - Removed `machineId` property from telemetry payload in `src/extension.ts`

<sub>This will update automatically on new commits.</sub>