### PR TITLE
SLVSCODE-1832 Remove the SQC region selection checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -316,13 +316,6 @@
           "markdownDescription": "If enabled, by default, [focusing on new code](https://docs.sonarsource.com/sonarqube-for-vs-code/using/investigating-issues/#focusing-on-new-code) shows issues introduced in the last 30 days.\n\nFor the most accurate and customizable new code definition, use [Connected Mode](https://docs.sonarsource.com/sonarqube-for-vs-code/connect-your-ide/connected-mode) with SonarQube (Server, Cloud).",
           "scope": "machine"
         },
-        "sonarlint.earlyAccess.showRegionSelection": {
-          "order": 14,
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Show region selection while creating SonarQube Cloud Connection",
-          "scope": "machine"
-        },
         "sonarlint.output.showVerboseLogs": {
           "order": 90,
           "type": "boolean",

--- a/src/connected/connections.ts
+++ b/src/connected/connections.ts
@@ -12,7 +12,6 @@ import { SonarLintExtendedLanguageClient } from '../lsp/client';
 import { ConnectionCheckResult } from '../lsp/protocol';
 import { BaseConnection, ConnectionSettingsService, SonarCloudConnection } from '../settings/connectionsettings';
 import { DEFAULT_CONNECTION_ID } from '../commons';
-import { shouldShowRegionSelection } from '../settings/settings';
 
 type ConnectionStatus = 'ok' | 'notok' | 'loading';
 
@@ -103,14 +102,11 @@ export class AllConnectionsTreeDataProvider implements VSCode.TreeDataProvider<C
         : ConnectionSettingsService.instance.getSonarCloudConnections();
     const connections = await Promise.all(
       connectionsFromSettings.map(async c => {
-        // Display the region prefix in case user is in dogfooding, 
-        // has more than 1 SonarQube Cloud connections, and the region is set
-        const regionPrefix = 
-          shouldShowRegionSelection() &&
-          type !== '__sonarqube__'
-          && connectionsFromSettings.length > 1
-          && (c as SonarCloudConnection).region
-            ? `[${(c as SonarCloudConnection).region}] ` : '';
+        // Display the region prefix when there is more than one SonarQube Cloud connection and the region is set
+        const regionPrefix =
+          type !== '__sonarqube__' && connectionsFromSettings.length > 1 && (c as SonarCloudConnection).region
+            ? `[${(c as SonarCloudConnection).region}] `
+            : '';
         const label = c[labelKey] ? c[labelKey] : c[alternativeLabelKey];
         let status: ConnectionStatus = 'loading';
         const connectionId: string = c.connectionId ? c.connectionId : DEFAULT_CONNECTION_ID;

--- a/src/connected/connectionsetup.ts
+++ b/src/connected/connectionsetup.ts
@@ -22,7 +22,6 @@ import {
 import { Commands } from '../util/commands';
 import * as util from '../util/util';
 import { escapeHtml, ResourceResolver } from '../util/webview';
-import { shouldShowRegionSelection } from '../settings/settings';
 
 let connectionSetupPanel: vscode.WebviewPanel;
 
@@ -276,7 +275,7 @@ function renderConnectionSetupPanel(context: vscode.ExtensionContext, webview: v
   </html>`;
 }
 
-function renderServerUrlField(initialState, mode) {
+export function renderServerUrlField(initialState, mode) {
   if (isSonarQubeConnection(initialState.conn)) {
     const serverUrl = escapeHtml(initialState.conn.serverUrl);
     return `<vscode-text-field id="serverUrl" type="url" placeholder="https://your.sonarqube.server/" required size="40"
@@ -287,14 +286,13 @@ function renderServerUrlField(initialState, mode) {
   }
 
   // SonarQube Cloud connection - pre-populate region field if available
-  const hidden = !shouldShowRegionSelection();
   const region = initialState.conn.region ?? 'EU';
   const euChecked = region === 'EU' ? 'checked' : '';
   const usChecked = region === 'US' ? 'checked' : '';
-  return `<vscode-radio-group orientation=vertical id="region" ${mode === 'update' ? 'disabled' : ''} ${hidden ? 'hidden' : ''}>
+  return `<vscode-radio-group orientation=vertical id="region" ${mode === 'update' ? 'disabled' : ''}>
             <label slot="label">Select the SonarQube Cloud region you would like to connect to</label>
             <vscode-radio ${euChecked} value="EU"><b>EU</b> - sonarcloud.io</vscode-radio>
-            <vscode-radio ${usChecked} value="US"><b>US</b> - sonarqube.us</vscode-radio>
+            <vscode-radio ${usChecked} value="US"><b>US</b> - sonarqube.us (invite-only)</vscode-radio>
           </vscode-radio-group>`;
 }
 

--- a/src/connected/sharedConnectedModeSettingsService.ts
+++ b/src/connected/sharedConnectedModeSettingsService.ts
@@ -18,7 +18,6 @@ import { FileSystemSubscriber } from '../fileSystem/fileSystemSubscriber';
 import { FileSystemServiceImpl } from '../fileSystem/fileSystemServiceImpl';
 import { SonarCloudRegion } from '../settings/connectionsettings';
 import { sonarCloudRegionToLabel } from '../util/util';
-import { shouldShowRegionSelection } from '../settings/settings';
 import { CustomQuickPickItem, deduplicateSuggestions } from '../util/connectionSuggestionUtils';
 
 const MAX_FOLDERS_TO_NOTIFY = 1;
@@ -113,8 +112,7 @@ export class SharedConnectedModeSettingsService implements FileSystemSubscriber 
   severalSharedConfigPoposalHandler(uniqueSuggestions, workspaceFolder) {
     return async () => {
       const quickPickItems: CustomQuickPickItem[] = uniqueSuggestions.map(s => {
-        const regionPrefix =
-          s.organization && shouldShowRegionSelection() ? `[${sonarCloudRegionToLabel(s.region)}] ` : '';
+        const regionPrefix = s.organization ? `[${sonarCloudRegionToLabel(s.region)}] ` : '';
         return {
           label: s.projectKey,
           description: s.organization || s.serverUrl,

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -79,10 +79,6 @@ function configKeyEquals(key, oldConfig, newConfig) {
   return oldConfig.get(key) === newConfig.get(key);
 }
 
-export function shouldShowRegionSelection() {
-  return getSonarLintConfiguration().get("earlyAccess.showRegionSelection", false);
-}
-
 export function isFocusingOnNewCode(): boolean {
   return getSonarLintConfiguration().get('focusOnNewCode', false);
 }

--- a/test/suite/connections.test.ts
+++ b/test/suite/connections.test.ts
@@ -132,10 +132,10 @@ suite('Connected Mode Test Suite', () => {
       expect(workspaceFolderNode.label).to.equal('sample-for-bindings');
     });
 
-    test('should return two element list when expanding SC and two connections exist', async () => {
+    test('should include regions when expanding SC and two connections exist', async () => {
       const testSCConfig = [
-        { organizationKey: 'myOrg1', token: 'ggggg' },
-        { organizationKey: 'myOrg2', token: 'ddddd' }
+        { organizationKey: 'myOrg1', token: 'ggggg', region: 'EU' },
+        { organizationKey: 'myOrg2', token: 'ddddd', region: 'US' }
       ];
       await vscode.workspace
         .getConfiguration('sonarlint')
@@ -146,8 +146,8 @@ suite('Connected Mode Test Suite', () => {
       const sonarCloudChildren = await underTest.getChildren(SCGroup);
 
       expect(sonarCloudChildren.length).to.equal(2);
-      expect(sonarCloudChildren[0].label).to.equal(testSCConfig[0].organizationKey);
-      expect(sonarCloudChildren[1].label).to.equal(testSCConfig[1].organizationKey);
+      expect(sonarCloudChildren[0].label).to.equal('[EU] ' + testSCConfig[0].organizationKey);
+      expect(sonarCloudChildren[1].label).to.equal('[US] ' + testSCConfig[1].organizationKey);
     });
 
     test('should return two element list with proper icons when expanding SC and two connections exist', async () => {
@@ -174,9 +174,9 @@ suite('Connected Mode Test Suite', () => {
       const sonarCloudChildren = await underTest.getChildren(SCGroup);
 
       expect(sonarCloudChildren.length).to.equal(2);
-      expect(sonarCloudChildren[0].label).to.equal(testSCConfig[0].connectionId);
+      expect(sonarCloudChildren[0].label).to.equal('[EU] ' + testSCConfig[0].connectionId);
       expect((sonarCloudChildren[0].iconPath as ThemeIcon).id).to.equal('pass');
-      expect(sonarCloudChildren[1].label).to.equal(testSCConfig[1].connectionId);
+      expect(sonarCloudChildren[1].label).to.equal('[EU] ' + testSCConfig[1].connectionId);
       expect((sonarCloudChildren[1].iconPath as ThemeIcon).id).to.equal('error');
     });
   });

--- a/test/suite/connectionsetup.test.ts
+++ b/test/suite/connectionsetup.test.ts
@@ -12,7 +12,8 @@ import { Commands } from '../../src/util/commands';
 import {
   getDefaultConnectionId,
   handleMessageWithConnectionSettingsService,
-  handleInvalidTokenNotification
+  handleInvalidTokenNotification,
+  renderServerUrlField
 } from '../../src/connected/connectionsetup';
 import { ConnectionSettingsService } from '../../src/settings/connectionsettings';
 import { SonarLintExtendedLanguageClient } from '../../src/lsp/client';
@@ -68,6 +69,16 @@ suite('Connection Setup', () => {
     this.timeout(SETUP_TEARDOWN_HOOK_TIMEOUT);
     await deleteConnectedModeSettings();
     await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+  });
+
+  test('should show SonarQube Cloud region selection defaulting to EU', () => {
+    const html = renderServerUrlField({ conn: { organizationKey: '', connectionId: '', token: '' } }, 'create');
+
+    assert.include(html, 'id="region"');
+    assert.include(html, '<vscode-radio checked value="EU">');
+    assert.include(html, '<b>US</b> - sonarqube.us (invite-only)');
+    assert.notInclude(html, 'checked value="US"');
+    assert.notInclude(html, 'hidden');
   });
 
   test('should show SonarQube creation webview when command is called', async () => {


### PR DESCRIPTION
----
## Summary by Gitar

- **Connected mode:**
    - Removed region selection checkbox and associated `shouldShowRegionSelection` checks across connection settings and setup
    - Updated connection setup and tree data provider tests for region handling

<sub>This will update automatically on new commits.</sub>