### PR TITLE
SLVSCODE-1859 Reflect Node.js 22.12 minimum required by SonarJS 13.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
-          version: 2025.7.12
+          version: 2026.8.9
 
       - name: Vault Secrets
         id: secrets
@@ -161,7 +161,7 @@ jobs:
 
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
-          version: 2025.7.12
+          version: 2026.8.9
 
       - name: Vault Secrets
         id: secrets
@@ -239,7 +239,7 @@ jobs:
 
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
-          version: 2025.7.12
+          version: 2026.8.9
 
       - name: Vault Secrets
         id: secrets
@@ -304,7 +304,7 @@ jobs:
 
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
-          version: 2025.7.12
+          version: 2026.8.9
 
       - name: Vault Secrets
         id: secrets
@@ -415,7 +415,7 @@ jobs:
 
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
-          version: 2025.7.12
+          version: 2026.8.9
 
       - name: Vault Secrets
         id: secrets

--- a/.github/workflows/shadow-scans.yml
+++ b/.github/workflows/shadow-scans.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
-          version: 2025.7.12
+          version: 2026.8.9
 
       - name: Fetch vault secrets
         id: secrets

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-node = '20'
+node = '24'
 jfrog-cli = "2.77.0"
 # needed to run ITs, takes precedence over runner built-in Java
 java = '21'

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
         "sonarlint.pathToNodeExecutable": {
           "order": 10,
           "type": "string",
-          "markdownDescription": "Path to a Node.js executable (versions above 20.12.0, or 22.11.0) used to analyze JavaScript and TypeScript code. \nOn Windows, backslashes must be escaped, e.g. `C:\\\\Program Files\\\\NodeJS\\\\20-lts\\\\bin\\\\node.exe`",
+          "markdownDescription": "Path to a Node.js executable (versions above 22.12.0, or 24.0.0) used to analyze JavaScript and TypeScript code. \nOn Windows, backslashes must be escaped, e.g. `C:\\\\Program Files\\\\NodeJS\\\\22-lts\\\\bin\\\\node.exe`",
           "scope": "resource"
         },
         "sonarlint.ls.javaHome": {


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **Configuration updates:**
    - Updated minimum Node.js version requirement to `22.12.0` or `24.0.0` in `package.json`
    - Bumped tool version to `24` in `mise.toml`
- **CI/CD updates:**
    - Bumped `mise-action` version to `2026.8.9` in GitHub workflows

<sub>This will update automatically on new commits.</sub>