### PR TITLE
SLVSCODE-1870 Revert java-symbolic-execution update and bump version to 5.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 * Update JS/TS/CSS analyzer 13.4 -> [13.5](https://github.com/SonarSource/SonarJS/releases/tag/13.5.0.44127) -> [13.6](https://github.com/SonarSource/SonarJS/releases/tag/13.6.0.44263) -> [13.7](https://github.com/SonarSource/SonarJS/releases/tag/13.7.0.44407)
 * Update IaC analyzer 2.13 -> [2.14](https://github.com/SonarSource/sonar-iac/releases/tag/2.14.0.22356) -> [2.15](https://github.com/SonarSource/sonar-iac/releases/tag/2.15.0.22475)
 * Update Go analyzer 1.40 -> [1.41](https://github.com/SonarSource/sonar-go/releases/tag/1.41.0.7435)
-* Update Java Symbolic Execution analyzer 8.16 -> [8.22](https://github.com/SonarSource/sonar-java-symbolic-execution/releases/tag/8.22.0.2207)
 
 ## 5.7
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sonarlint-vscode",
-  "version": "5.9.0",
+  "version": "5.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sonarlint-vscode",
-      "version": "5.9.0",
+      "version": "5.9.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@openpgp/web-stream-tools": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sonarlint-vscode",
   "displayName": "SonarQube for IDE",
   "description": "Advanced linter to detect & fix coding issues locally in JS/TS, Python, Java, C#, C/C++, Go, PHP.  Use with SonarQube (Server, Cloud) for optimal team performance.",
-  "version": "5.9.0",
+  "version": "5.9.1",
   "icon": "images/sonarqube_for_ide_128px.png",
   "publisher": "SonarSource",
   "homepage": "https://www.sonarsource.com/products/sonarlint/",
@@ -1511,7 +1511,7 @@
     {
       "groupId": "org.sonarsource.java",
       "artifactId": "sonar-java-symbolic-execution-plugin",
-      "version": "8.22.0.2207",
+      "version": "8.16.4.1912",
       "output": "analyzers/sonarjavasymbolicexecution.jar"
     },
     {


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **Version update:**
    - Bumped project version to `5.9.1` in `package.json`
- **Analyzer update:**
    - Downgraded `sonar-java-symbolic-execution-plugin` version to `8.16.4.1912`

<sub>This will update automatically on new commits.</sub>