### PR TITLE
Detect Devin IDE (rebranded Windsurf) for AI agent MCP and hooks configuration

### DIFF
--- a/src/aiAgentsConfiguration/aiAgentUtils.ts
+++ b/src/aiAgentsConfiguration/aiAgentUtils.ts
@@ -20,14 +20,20 @@ function isCopilotInstalledAndActive(): boolean {
   return copilotExtension?.isActive;
 }
 
+// Windsurf was rebranded to Devin; both share the same configuration layout under ~/.codeium
+function isWindsurfBasedIde(appName: string): boolean {
+  return appName.includes('windsurf') || appName.includes('devin');
+}
+
 export function getCurrentAgentWithMCPSupport(): AGENT | undefined {
-  if (vscode.env.appName.toLowerCase().includes('cursor')) {
+  const appName = vscode.env.appName.toLowerCase();
+  if (appName.includes('cursor')) {
     return AGENT.CURSOR;
-  } else if (vscode.env.appName.toLowerCase().includes('windsurf')) {
+  } else if (isWindsurfBasedIde(appName)) {
     return AGENT.WINDSURF;
-  } else if (vscode.env.appName.toLowerCase().includes('kiro')) {
+  } else if (appName.includes('kiro')) {
     return AGENT.KIRO;
-  } else if (vscode.env.appName.toLowerCase().includes('visual studio code') && isCopilotInstalledAndActive()) {
+  } else if (appName.includes('visual studio code') && isCopilotInstalledAndActive()) {
     return AGENT.GITHUB_COPILOT;
   }
   return undefined;
@@ -35,8 +41,8 @@ export function getCurrentAgentWithMCPSupport(): AGENT | undefined {
 
 export function getCurrentAgentWithHookSupport(): AGENT | undefined {
   const appName = vscode.env.appName.toLowerCase();
-  // Hooks are available on all Windsurf versions
-  if (appName.includes('windsurf')) {
+  // Hooks are available on all Windsurf / Devin versions
+  if (isWindsurfBasedIde(appName)) {
     return AGENT.WINDSURF;
   }
   return undefined;

--- a/test/suite/aiAgentsConfiguration/aiAgentHooks.test.ts
+++ b/test/suite/aiAgentsConfiguration/aiAgentHooks.test.ts
@@ -81,6 +81,16 @@ suite('aiAgentHooks', () => {
       expect(getCurrentAgentWithHookSupport()).to.equal(AGENT.WINDSURF);
     });
 
+    test('should return WINDSURF for Devin (rebranded Windsurf)', () => {
+      envStub.value('Devin');
+      expect(getCurrentAgentWithHookSupport()).to.equal(AGENT.WINDSURF);
+    });
+
+    test('should return WINDSURF for Devin Next', () => {
+      envStub.value('Devin Next');
+      expect(getCurrentAgentWithHookSupport()).to.equal(AGENT.WINDSURF);
+    });
+
     test('should return undefined for Cursor (not yet supported)', () => {
       envStub.value('Cursor');
       expect(getCurrentAgentWithHookSupport()).to.be.undefined;
@@ -244,6 +254,20 @@ suite('aiAgentHooks', () => {
 
     test('should use windsurf-next directory when app name includes next', async () => {
       envStub.value('Windsurf Next');
+      homedirStub.returns('/home/test');
+      fsPromisesStub.readFile.rejects(new Error('File not found'));
+
+      await installHook(mockLanguageClient, AGENT.WINDSURF);
+
+      expect(fsPromisesStub.mkdir.called).to.be.true;
+      const mkdirCall = fsPromisesStub.mkdir.getCalls().find(call => 
+        call.args[0] && call.args[0].includes('windsurf-next')
+      );
+      expect(mkdirCall).to.not.be.undefined;
+    });
+
+    test('should use windsurf-next directory when Devin Next app name is used', async () => {
+      envStub.value('Devin Next');
       homedirStub.returns('/home/test');
       fsPromisesStub.readFile.rejects(new Error('File not found'));
 

--- a/test/suite/aiAgentsConfiguration/aiAgentHooks.test.ts
+++ b/test/suite/aiAgentsConfiguration/aiAgentHooks.test.ts
@@ -271,7 +271,9 @@ suite('aiAgentHooks', () => {
       homedirStub.returns('/home/test');
       fsPromisesStub.readFile.rejects(new Error('File not found'));
 
-      await installHook(mockLanguageClient, AGENT.WINDSURF);
+      const agent = getCurrentAgentWithHookSupport();
+      expect(agent).to.equal(AGENT.WINDSURF);
+      await installHook(mockLanguageClient, agent);
 
       expect(fsPromisesStub.mkdir.called).to.be.true;
       const mkdirCall = fsPromisesStub.mkdir.getCalls().find(call => 

--- a/test/suite/aiAgentsConfiguration/mcpServerConfig.test.ts
+++ b/test/suite/aiAgentsConfiguration/mcpServerConfig.test.ts
@@ -41,6 +41,9 @@ suite('mcpServerConfig', () => {
       envStub.value('Windsurf');
       expect(getCurrentAgentWithMCPSupport()).to.equal(AGENT.WINDSURF);
 
+      envStub.value('Devin');
+      expect(getCurrentAgentWithMCPSupport()).to.equal(AGENT.WINDSURF);
+
       envStub.value('Kiro');
       expect(getCurrentAgentWithMCPSupport()).to.equal(AGENT.KIRO);
 
@@ -76,6 +79,9 @@ suite('mcpServerConfig', () => {
       envStub.value('Windsurf');
       const windsurfPath = getMCPConfigPath();
 
+      envStub.value('Devin');
+      const devinPath = getMCPConfigPath();
+
       envStub.value('Kiro');
       const kiroPath = getMCPConfigPath();
 
@@ -97,6 +103,7 @@ suite('mcpServerConfig', () => {
 
       expect(cursorPath).to.match(/mcp\.json$/);
       expect(windsurfPath).to.match(/mcp_config\.json$/);
+      expect(devinPath).to.equal(windsurfPath);
       expect(kiroPath).to.match(/mcp\.json$/);
       expect(vscodePath).to.match(/mcp\.json$/);
     } finally {


### PR DESCRIPTION
Part of 

Please review our [contribution guidelines](https://github.com/SonarSource/sonarlint-vscode/blob/master/docs/contributing.md).

> **Note: this fix spans two repositories.** This PR restores the AI Agents Configuration view (MCP server, rules file, hook installer) on Devin. For the installed hook to actually run analyses, the companion change in `sonarlint-language-server` is also required: https://github.com/SonarSource/sonarlint-language-server/pull/756 (opened as a separate PR; both should land together).

### Motivation

Windsurf IDE has been rebranded to **Devin** (Cognition). `vscode.env.appName` is now `"Devin"` (`product.json`: `nameShort: "Devin"`, `applicationName: "devin-desktop"`), so the extension no longer recognizes the editor as Windsurf: `getCurrentAgentWithMCPSupport()` / `getCurrentAgentWithHookSupport()` return `undefined` and the whole **AI Agents Configuration** view (MCP server setup, agent rules file, "Install Hook for Code Analysis") disappears.

The on-disk layout did not change — the Devin Desktop IDE still uses `~/.codeium/windsurf[-next]/mcp_config.json`, `~/.codeium/windsurf[-next]/hooks.json` and `.windsurf/rules` in the workspace (see https://docs.devin.ai/desktop/cascade/mcp and https://docs.devin.ai/desktop/cascade/hooks). So the existing `AGENT.WINDSURF` code paths remain correct; only the app-name detection needs to also accept `devin`.

### Change

`src/aiAgentsConfiguration/aiAgentUtils.ts`:

```ts
function isWindsurfBasedIde(appName: string): boolean {
  return appName.includes('windsurf') || appName.includes('devin');
}
```

used by both `getCurrentAgentWithMCPSupport()` and `getCurrentAgentWithHookSupport()` in place of `includes('windsurf')`. `getWindsurfDirectory()` is unchanged, so `"Devin Next"` keeps mapping to `windsurf-next`.

### Companion change (required for hook execution)

MCP config and the rules file work with this PR alone. For the hook to actually analyze files, the language server must also report `ideName: "Windsurf"` for Devin — today `BackendServiceFacade.determineIdeName("Devin")` falls back to `"Visual Studio Code"`, and the generated hook script (`AiHookService.getIdeName(WINDSURF)`) only accepts `"Windsurf"`, so it ends with "Backend not found". That is addressed by the companion `sonarlint-language-server` PR linked above.

### Tests

Added assertions/tests in `test/suite/aiAgentsConfiguration/mcpServerConfig.test.ts` and `aiAgentHooks.test.ts` for `Devin` / `Devin Next` app names. `npm run compile` clean; the two `aiAgentsConfiguration` test files pass (40 tests) with `xvfb-run -a node out/test/runTest.js`.

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SLVSCODE) ticket available, please make your commits and pull request start with the ticket ID (SLVSCODE-XXXX)