### PR TITLE
SLVSCODE-1871 SLVSCODE-1880 SLVSCODE-1881 SLVSCODE-1899 SLVSCODE-1906 SLVSCODE-1907 5.10 analyzer updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.10
+* Update IaC analyzer 2.15 -> [2.16](https://github.com/SonarSource/sonar-iac/releases/tag/2.16.0.22905)
+
 ## 5.9
 * Update Go analyzer 1.41 -> [1.42](https://github.com/SonarSource/sonar-go/releases/tag/1.42.0.7579) -> [1.43](https://github.com/SonarSource/sonar-go/releases/tag/1.43.0.7704)
 * Update Java analyzer 8.39 -> [8.40](https://github.com/SonarSource/sonar-java/releases/tag/8.40.0.46617) -> [8.41](https://github.com/SonarSource/sonar-java/releases/tag/8.41.0.47177)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Update IaC analyzer 2.15 -> [2.16](https://github.com/SonarSource/sonar-iac/releases/tag/2.16.0.22905) -> [2.17](https://github.com/SonarSource/sonar-iac/releases/tag/2.17.0.23172)
 * Update JS/TS/CSS analyzer 13.8 -> [13.9](https://github.com/SonarSource/SonarJS/releases/tag/13.9.0.44793)
 * Update Text & Secrets analyzer 2.49 -> [2.50](https://github.com/SonarSource/sonar-text/releases/tag/2.50.0.13411)
+* Update Go analyzer 1.43 -> [1.44](https://github.com/SonarSource/sonar-go/releases/tag/1.44.0.8969)
 
 ## 5.9
 * Update Go analyzer 1.41 -> [1.42](https://github.com/SonarSource/sonar-go/releases/tag/1.42.0.7579) -> [1.43](https://github.com/SonarSource/sonar-go/releases/tag/1.43.0.7704)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.10
-* Update IaC analyzer 2.15 -> [2.16](https://github.com/SonarSource/sonar-iac/releases/tag/2.16.0.22905) -> [2.17](https://github.com/SonarSource/sonar-iac/releases/tag/2.17.0.23172)
+* Update IaC analyzer 2.15 -> [2.16](https://github.com/SonarSource/sonar-iac/releases/tag/2.16.0.22905) -> [2.17](https://github.com/SonarSource/sonar-iac/releases/tag/2.17.0.23172) -> [2.18](https://github.com/SonarSource/sonar-iac/releases/tag/2.18.0.23895)
 * Update JS/TS/CSS analyzer 13.8 -> [13.9](https://github.com/SonarSource/SonarJS/releases/tag/13.9.0.44793)
 * Update Text & Secrets analyzer 2.49 -> [2.50](https://github.com/SonarSource/sonar-text/releases/tag/2.50.0.13411)
 * Update Go analyzer 1.43 -> [1.44](https://github.com/SonarSource/sonar-go/releases/tag/1.44.0.8969)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.10
 * Update IaC analyzer 2.15 -> [2.16](https://github.com/SonarSource/sonar-iac/releases/tag/2.16.0.22905) -> [2.17](https://github.com/SonarSource/sonar-iac/releases/tag/2.17.0.23172)
 * Update JS/TS/CSS analyzer 13.8 -> [13.9](https://github.com/SonarSource/SonarJS/releases/tag/13.9.0.44793)
+* Update Text & Secrets analyzer 2.49 -> [2.50](https://github.com/SonarSource/sonar-text/releases/tag/2.50.0.13411)
 
 ## 5.9
 * Update Go analyzer 1.41 -> [1.42](https://github.com/SonarSource/sonar-go/releases/tag/1.42.0.7579) -> [1.43](https://github.com/SonarSource/sonar-go/releases/tag/1.43.0.7704)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.10
 * Update IaC analyzer 2.15 -> [2.16](https://github.com/SonarSource/sonar-iac/releases/tag/2.16.0.22905) -> [2.17](https://github.com/SonarSource/sonar-iac/releases/tag/2.17.0.23172)
+* Update JS/TS/CSS analyzer 13.8 -> [13.9](https://github.com/SonarSource/SonarJS/releases/tag/13.9.0.44793)
 
 ## 5.9
 * Update Go analyzer 1.41 -> [1.42](https://github.com/SonarSource/sonar-go/releases/tag/1.42.0.7579) -> [1.43](https://github.com/SonarSource/sonar-go/releases/tag/1.43.0.7704)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.10
-* Update IaC analyzer 2.15 -> [2.16](https://github.com/SonarSource/sonar-iac/releases/tag/2.16.0.22905)
+* Update IaC analyzer 2.15 -> [2.16](https://github.com/SonarSource/sonar-iac/releases/tag/2.16.0.22905) -> [2.17](https://github.com/SonarSource/sonar-iac/releases/tag/2.17.0.23172)
 
 ## 5.9
 * Update Go analyzer 1.41 -> [1.42](https://github.com/SonarSource/sonar-go/releases/tag/1.42.0.7579) -> [1.43](https://github.com/SonarSource/sonar-go/releases/tag/1.43.0.7704)

--- a/package.json
+++ b/package.json
@@ -1547,7 +1547,7 @@
     {
       "groupId": "org.sonarsource.iac",
       "artifactId": "sonar-iac-plugin",
-      "version": "2.15.0.22475",
+      "version": "2.16.0.22905",
       "output": "analyzers/sonariac.jar"
     },
     {

--- a/package.json
+++ b/package.json
@@ -1493,7 +1493,7 @@
     {
       "groupId": "org.sonarsource.go",
       "artifactId": "sonar-go-plugin",
-      "version": "1.43.0.7704",
+      "version": "1.44.0.8969",
       "output": "analyzers/sonargo.jar"
     },
     {

--- a/package.json
+++ b/package.json
@@ -1547,7 +1547,7 @@
     {
       "groupId": "org.sonarsource.iac",
       "artifactId": "sonar-iac-plugin",
-      "version": "2.16.0.22905",
+      "version": "2.17.0.23172",
       "output": "analyzers/sonariac.jar"
     },
     {

--- a/package.json
+++ b/package.json
@@ -1541,7 +1541,7 @@
     {
       "groupId": "org.sonarsource.text",
       "artifactId": "sonar-text-plugin",
-      "version": "2.49.0.12346",
+      "version": "2.50.0.13411",
       "output": "analyzers/sonartext.jar"
     },
     {

--- a/package.json
+++ b/package.json
@@ -1499,7 +1499,7 @@
     {
       "groupId": "org.sonarsource.javascript",
       "artifactId": "sonar-javascript-plugin",
-      "version": "13.8.0.44569",
+      "version": "13.9.0.44793",
       "output": "analyzers/sonarjs.jar"
     },
     {

--- a/package.json
+++ b/package.json
@@ -1547,7 +1547,7 @@
     {
       "groupId": "org.sonarsource.iac",
       "artifactId": "sonar-iac-plugin",
-      "version": "2.17.0.23172",
+      "version": "2.18.0.23895",
       "output": "analyzers/sonariac.jar"
     },
     {


### PR DESCRIPTION
Analyzer updates for the 5.10 release.

- SLVSCODE-1871 Update iac to 2.16.0.22905
- SLVSCODE-1880 Update iac to 2.17.0.23172
- SLVSCODE-1881 Update javascript to 13.9.0.44793
- SLVSCODE-1899 Update text to 2.50.0.13411
- SLVSCODE-1906 Update go to 1.44.0.8969
- SLVSCODE-1907 Update iac to 2.18.0.23895

No package-lock.json changes needed — the `jarDependencies` entries bumped here are custom metadata for the analyzer JAR downloader, not real npm dependencies, so there's nothing for npm to re-resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)